### PR TITLE
Refactors service action builders

### DIFF
--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import TecoCodeGeneratorCommons
 
-func buildInitializerParameterList(for members: [APIObject.Member], packed: Bool = false) -> FunctionParameterListSyntax {
+func buildInitializerParameterList(for members: [APIObject.Member]) -> FunctionParameterListSyntax {
     func getDefaultArgument(for member: APIObject.Member) -> ExprSyntax? {
         let type = getSwiftType(for: member, isInitializer: true)
         if let defaultValue = member.default, member.required {
@@ -25,11 +25,10 @@ func buildInitializerParameterList(for members: [APIObject.Member], packed: Bool
     return FunctionParameterListSyntax {
         for member in members {
             FunctionParameterSyntax(
-                firstName: TokenSyntax("\(raw: member.identifier)"),
+                firstName: "\(raw: member.identifier)",
                 colon: .colonToken(),
                 type: TypeSyntax("\(raw: getSwiftType(for: member, isInitializer: true))"),
-                defaultArgument: getDefaultArgument(for: member).map { .init(value: $0) },
-                trailingComma: packed ? .commaToken() : nil
+                defaultArgument: getDefaultArgument(for: member).map { .init(value: $0) }
             )
         }
     }

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -128,10 +128,10 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                             try buildResponseModelDecl(for: metadata.output, metadata: output, paginated: pagination != nil)
 
                             buildActionDecl(for: action, metadata: metadata, discardableResult: discardableOutput)
-                            buildAsyncActionDecl(for: action, metadata: metadata, discardableResult: discardableOutput)
+                            buildActionDecl(for: action, metadata: metadata, discardableResult: discardableOutput, async: true)
 
                             buildUnpackedActionDecl(for: action, metadata: metadata, inputMembers: inputMembers, discardableResult: discardableOutput)
-                            buildUnpackedAsyncActionDecl(for: action, metadata: metadata, inputMembers: inputMembers, discardableResult: discardableOutput)
+                            buildUnpackedActionDecl(for: action, metadata: metadata, inputMembers: inputMembers, discardableResult: discardableOutput, async: true)
 
                             if metadata.status != .deprecated, pagination != nil {
                                 buildPaginatedActionDecl(for: action, metadata: metadata, output: output)

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -127,11 +127,11 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                             try buildRequestModelDecl(for: metadata.input, metadata: input, pagination: pagination, output: (metadata.output, output))
                             try buildResponseModelDecl(for: metadata.output, metadata: output, paginated: pagination != nil)
 
-                            buildActionDecl(for: action, metadata: metadata, discardableResult: discardableOutput)
-                            buildActionDecl(for: action, metadata: metadata, discardableResult: discardableOutput, async: true)
+                            try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput)
+                            try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput, async: true)
 
-                            buildUnpackedActionDecl(for: action, metadata: metadata, inputMembers: inputMembers, discardableResult: discardableOutput)
-                            buildUnpackedActionDecl(for: action, metadata: metadata, inputMembers: inputMembers, discardableResult: discardableOutput, async: true)
+                            try buildActionDecl(for: action, metadata: metadata, input: inputMembers, discardable: discardableOutput)
+                            try buildActionDecl(for: action, metadata: metadata, input: inputMembers, discardable: discardableOutput, async: true)
 
                             if metadata.status != .deprecated, pagination != nil {
                                 buildPaginatedActionDecl(for: action, metadata: metadata, output: output)

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -133,11 +133,11 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                             try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput)
                             try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput, async: true)
 
-                            if metadata.status != .deprecated, pagination != nil {
-                                buildPaginatedActionDecl(for: action, metadata: metadata, output: output)
-                                buildPaginatedActionWithCallbackDecl(for: action, metadata: metadata, output: output)
+                            if pagination != nil {
+                                try buildPaginatedActionDecl(for: action, metadata: metadata, output: output)
+                                try buildPaginatedActionWithCallbackDecl(for: action, metadata: metadata, output: output)
 
-                                buildActionPaginatorDecl(for: action, metadata: metadata, output: output)
+                                try buildActionPaginatorDecl(for: action, metadata: metadata, output: output)
                             }
                         }
                     }.withCopyrightHeader()

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -130,8 +130,8 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput)
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput, async: true)
 
-                            try buildActionDecl(for: action, metadata: metadata, input: inputMembers, discardable: discardableOutput)
-                            try buildActionDecl(for: action, metadata: metadata, input: inputMembers, discardable: discardableOutput, async: true)
+                            try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput)
+                            try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput, async: true)
 
                             if metadata.status != .deprecated, pagination != nil {
                                 buildPaginatedActionDecl(for: action, metadata: metadata, output: output)

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -1,3 +1,5 @@
+import SwiftSyntax
+
 enum ServiceContext {
     @TaskLocal
     static var objects: [String : APIObject] = [:]
@@ -8,3 +10,8 @@ func skipAuthorizationParameter(for action: String) -> String {
     return action.hasPrefix("AssumeRoleWith") ? ", skipAuthorization: true" : ""
 }
 
+extension SyntaxProtocol {
+    func spaced() -> Self {
+        self.with(\.leadingTrivia, .space)
+    }
+}


### PR DESCRIPTION
This PR includes various improvements to action generation:
- Unavailable function bodies are replaced by `fatalError`.
- Unpacked actions are now convenience wrappers;
- Actions now use the same builder implementation;
- Pagination APIs now use the same signature builder with actions.