### PR TITLE
Prepares for Teco 0.2.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,6 @@ jobs:
           - release
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: '5.7'
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/Package.resolved
+++ b/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teco-project/teco-core.git",
       "state" : {
-        "revision" : "e7e91edfa299cd22649a0060d9922bc62df6419c",
-        "version" : "0.4.0"
+        "revision" : "5e4fb1db7a9f1260563f6c6112393b203bd03df5",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-syntax.git", exact: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-03-27-a"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-        .package(url: "https://github.com/teco-project/teco-core.git", from: "0.4.0"),
+        .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/TecoPackageGenerator/generator.swift
+++ b/Sources/TecoPackageGenerator/generator.swift
@@ -17,7 +17,7 @@ struct TecoPackageGenerator: TecoCodeGenerator {
     var serviceGenerator: URL?
 
     @Option(name: .long)
-    var tecoCoreRequirement: String = #".upToNextMinor(from: "0.5.0-beta.1")"#
+    var tecoCoreRequirement: String = #".upToNextMinor(from: "0.5.0")"#
 
     @Flag
     var dryRun: Bool = false


### PR DESCRIPTION
This PR bumps `teco-core` version to `0.5.0` and unblocks Swift 5.8.