### PR TITLE
Updates `import` generation for Teco

### DIFF
--- a/Sources/TecoServiceGenerator/builder.swift
+++ b/Sources/TecoServiceGenerator/builder.swift
@@ -5,16 +5,27 @@ import TecoCodeGeneratorCommons
 func buildTecoCoreImportDecls(models: some Collection<APIObject> = [], pagination: Pagination? = nil, exported: Bool = false) -> CodeBlockItemListSyntax {
     let requireDatehelpers = models.flatMap(\.members).contains(where: { $0.dateType != nil })
     let requirePaginationHelpers = pagination != nil
-    return CodeBlockItemListSyntax {
-        if requireDatehelpers {
-            DeclSyntax("@_exported import struct Foundation.Date")
+
+    if exported {
+        return CodeBlockItemListSyntax {
+            DeclSyntax("@_exported import TecoCore")
+            if requireDatehelpers {
+                DeclSyntax("@_exported import struct Foundation.Date")
+                    .with(\.leadingTrivia, .newlines(2))
+            }
         }
-        DeclSyntax("\(raw: exported ? "@_exported " : "")import TecoCore")
-        if requireDatehelpers {
-            DeclSyntax("import TecoDateHelpers")
-        }
-        if requirePaginationHelpers {
-            DeclSyntax("import TecoPaginationHelpers")
+    } else {
+        return CodeBlockItemListSyntax {
+            if requireDatehelpers {
+                DeclSyntax("import struct Foundation.Date")
+            }
+            DeclSyntax("import TecoCore")
+            if requireDatehelpers {
+                DeclSyntax("import TecoDateHelpers")
+            }
+            if requirePaginationHelpers {
+                DeclSyntax("import TecoPaginationHelpers")
+            }
         }
     }
 }

--- a/Sources/TecoServiceGenerator/builders/Action.swift
+++ b/Sources/TecoServiceGenerator/builders/Action.swift
@@ -68,7 +68,7 @@ private func buildUnpackedExecuteExpr(for action: String, metadata: APIModel.Act
 private func buildPaginateExpr(for action: String, extraArguments: [(String, String)] = []) -> ExprSyntax {
     let extraArgs = TupleExprElementListSyntax {
         for (label, value) in extraArguments {
-            TupleExprElementSyntax(label: .identifier(label), colon: .colonToken(), expression: ExprSyntax("\(raw: value)"), trailingComma: .commaToken())
+            TupleExprElementSyntax(label: label, expression: ExprSyntax("\(raw: value)")).with(\.trailingComma, .commaToken())
         }
     }
     return ExprSyntax("self.client.paginate(input: input, region: region, command: self.\(raw: action.lowerFirst()), \(extraArgs)logger: logger, on: eventLoop)")

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -67,11 +67,22 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                 models.sort()
             }
 
+            // MARK: Generate re-exported interface
+
+            do {
+                let sourceFile = SourceFileSyntax {
+                    let imports = buildTecoCoreImportDecls(models: ServiceContext.objects.values, exported: true)
+                    IfConfigDeclSyntax(clauses: [.init(poundKeyword: .poundIfKeyword(), condition: ExprSyntax("!BUILDING_DOCC"), elements: .statements(imports))])
+                }.withCopyrightHeader()
+
+                try sourceFile.save(to: outputDir.appendingPathComponent("exports.swift"))
+            }
+
             // MARK: Generate client source
 
             do {
                 let sourceFile = try SourceFileSyntax {
-                    buildTecoCoreImportDecls(exported: true)
+                    buildTecoCoreImportDecls()
                     try buildServiceDecl(with: service, withErrors: !errors.isEmpty)
                     try buildServicePatchSupportDecl(for: serviceName)
                 }.withCopyrightHeader()

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -71,7 +71,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
             do {
                 let sourceFile = SourceFileSyntax {
-                    let imports = buildTecoCoreImportDecls(models: ServiceContext.objects.values, exported: true)
+                    let imports = buildTecoCoreImportDecls(for: .exports(ServiceContext.objects.values))
                     IfConfigDeclSyntax(clauses: [.init(poundKeyword: .poundIfKeyword(), condition: ExprSyntax("!BUILDING_DOCC"), elements: .statements(imports))])
                 }.withCopyrightHeader()
 
@@ -82,7 +82,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
             do {
                 let sourceFile = try SourceFileSyntax {
-                    buildTecoCoreImportDecls()
+                    buildTecoCoreImportDecls(for: .client)
                     try buildServiceDecl(with: service, withErrors: !errors.isEmpty)
                     try buildServicePatchSupportDecl(for: serviceName)
                 }.withCopyrightHeader()
@@ -94,7 +94,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
             if !models.isEmpty {
                 let sourceFile = try SourceFileSyntax {
-                    buildTecoCoreImportDecls(models: models.values)
+                    buildTecoCoreImportDecls(for: .models(models.values))
 
                     try ExtensionDeclSyntax("extension \(raw: serviceName)") {
                         for (model, metadata) in models {
@@ -126,7 +126,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                     let pagination = computePaginationKind(input: input, output: output, service: service, action: metadata)
 
                     let sourceFile = try SourceFileSyntax {
-                        buildTecoCoreImportDecls(models: [input, output], pagination: pagination)
+                        buildTecoCoreImportDecls(for: .action(input: input, output: output, pagination: pagination != nil))
 
                         let inputMembers = input.members.filter({ $0.type != .binary })
                         let discardableOutput = output.members.count == 1
@@ -164,7 +164,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                 let errorDomains = getErrorDomains(from: errors)
                 do {
                     let sourceFile = try SourceFileSyntax {
-                        buildTecoCoreImportDecls()
+                        buildTecoCoreImportDecls(for: .error)
 
                         try buildServiceErrorTypeDecl(serviceName)
                         try buildErrorStructDecl("TC\(serviceName)Error", domains: errorDomains, errorMap: generateErrorMap(from: errors), serviceName: serviceName)
@@ -178,7 +178,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                 for domain in errorDomains {
                     let errorMap = generateDomainedErrorMap(from: errors, for: domain)
                     let sourceFile = try SourceFileSyntax {
-                        buildTecoCoreImportDecls()
+                        buildTecoCoreImportDecls(for: .error)
 
                         try ExtensionDeclSyntax("extension TC\(raw: serviceName)Error") {
                             try buildErrorStructDecl(domain, errorMap: errorMap, serviceName: serviceName)


### PR DESCRIPTION
This PR adds support for opting out of `@_exported import`s in Teco, which was recently supported by `teco-core`. It generates a new `exports.swift` file for all `@_exported import` declarations.