### PR TITLE
Validates `--teco-core-requirement` input with `SwiftSyntax`

### DIFF
--- a/Sources/TecoPackageGenerator/generator.swift
+++ b/Sources/TecoPackageGenerator/generator.swift
@@ -16,8 +16,8 @@ struct TecoPackageGenerator: TecoCodeGenerator {
     @Option(name: .long, completion: .file(), transform: URL.init(fileURLWithPath:))
     var serviceGenerator: URL?
 
-    @Option(name: .long)
-    var tecoCoreRequirement: String = #".upToNextMinor(from: "0.5.0")"#
+    @Option(name: .long, transform: parseTupleExprElementSyntax)
+    var tecoCoreRequirement: TupleExprElementSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.0")"#))
 
     @Flag
     var dryRun: Bool = false

--- a/Sources/TecoPackageGenerator/helpers.swift
+++ b/Sources/TecoPackageGenerator/helpers.swift
@@ -1,4 +1,6 @@
 import class Foundation.Process
+import SwiftSyntax
+import SwiftSyntaxBuilder
 import TecoCodeGeneratorCommons
 
 typealias Target = (service: String, version: String)
@@ -38,4 +40,17 @@ func generateService(with generator: URL, manifest: URL, to directory: URL, erro
         )
     }
     return (directory.deletingLastPathComponent().lastPathComponent, directory.lastPathComponent)
+}
+
+func parseTupleExprElementSyntax(from source: String) throws -> TupleExprElementSyntax {
+    let separator = source.firstIndex(where: { !$0.isLetter && !$0.isNumber && $0 != "_" })
+    let (label, expression): (String?, String)
+    if let separator, source[separator] == ":" {
+        label = .init(source.prefix(upTo: separator))
+        expression = source.suffix(from: source.index(after: separator)).trimmingCharacters(in: .whitespaces)
+    } else {
+        (label, expression) = (nil, source)
+    }
+    let syntax = TupleExprElementSyntax(label: label, expression: ExprSyntax("\(raw: expression)"))
+    return try TupleExprElementSyntax(validating: syntax)
 }


### PR DESCRIPTION
This allows us to pre-check the input is valid Swift syntax, and also generates a nice-looking error message if the input is incorrect.