### PR TITLE
Replaces `ExprSyntax("nil")` with dedicated `NilLiteralExprSyntax()`

### DIFF
--- a/Sources/TecoServiceGenerator/builders/Action.swift
+++ b/Sources/TecoServiceGenerator/builders/Action.swift
@@ -37,12 +37,12 @@ private func buildActionParameterList(for action: APIModel.Action, unpacking inp
         } else {
             FunctionParameterSyntax(firstName: "_", secondName: TokenSyntax("input").spaced(), colon: .colonToken(), type: TypeSyntax("\(raw: action.input)"))
         }
-        FunctionParameterSyntax(firstName: "region", colon: .colonToken(), type: TypeSyntax("TCRegion?"), defaultArgument: .init(value: ExprSyntax("nil")))
+        FunctionParameterSyntax(firstName: "region", colon: .colonToken(), type: TypeSyntax("TCRegion?"), defaultArgument: .init(value: NilLiteralExprSyntax()))
         if let output {
             FunctionParameterSyntax(firstName: "onResponse", colon: .colonToken(), type: TypeSyntax("@escaping (\(output), EventLoop) -> EventLoopFuture<Bool>"))
         }
         FunctionParameterSyntax(firstName: "logger", colon: .colonToken(), type: TypeSyntax("Logger"), defaultArgument: .init(value: ExprSyntax("TCClient.loggingDisabled")))
-        FunctionParameterSyntax(firstName: "on", secondName: TokenSyntax("eventLoop").spaced(), colon: .colonToken(), type: TypeSyntax("EventLoop?"), defaultArgument: .init(value: ExprSyntax("nil")))
+        FunctionParameterSyntax(firstName: "on", secondName: TokenSyntax("eventLoop").spaced(), colon: .colonToken(), type: TypeSyntax("EventLoop?"), defaultArgument: .init(value: NilLiteralExprSyntax()))
     }
 }
 

--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -17,7 +17,7 @@ func buildInitializerParameterList(for members: [APIObject.Member]) -> FunctionP
             }
         }
         if !member.required {
-            return ExprSyntax("nil")
+            return NilLiteralExprSyntax().as(ExprSyntax.self)
         }
         return nil
     }


### PR DESCRIPTION
A tiny change to improve code clarity and robustness.