### PR TITLE
Generates developing years according to service version

### DIFF
--- a/Sources/TecoCodeGeneratorCommons/TecoCodeGenerator.swift
+++ b/Sources/TecoCodeGeneratorCommons/TecoCodeGenerator.swift
@@ -9,7 +9,7 @@ public struct GeneratorContext {
     public static var generator: String = "TecoCodeGenerator"
 
     @TaskLocal
-    public static var developingYears: String = "\(Calendar.current.component(.year, from: Date()))"
+    public static var developingYears: String = "\(Date().year)"
 
     @TaskLocal
     public static var dryRun: Bool = false
@@ -19,13 +19,17 @@ public protocol TecoCodeGenerator: AsyncParsableCommand {
     static var startingYear: Int { get }
     var dryRun: Bool { get }
 
+    var startingYear: Int { get }
+
     func generate() async throws
 }
 
 extension TecoCodeGenerator {
+    public var startingYear: Int { Self.startingYear }
+
     public func run() async throws {
         try await GeneratorContext.$generator.withValue("\(Self.self)") {
-            try await GeneratorContext.$developingYears.withValue(Self.developingYears) {
+            try await GeneratorContext.$developingYears.withValue(self.developingYears) {
                 if dryRun {
                     try await GeneratorContext.$dryRun.withValue(true, operation: generate)
                 } else {
@@ -35,7 +39,8 @@ extension TecoCodeGenerator {
         }
     }
 
-    private static var developingYears: String {
+    private var developingYears: String {
+        let startingYear = max(self.startingYear, Self.startingYear)
         if startingYear == Date().year {
             return "\(startingYear)"
         } else {

--- a/Sources/TecoPackageGenerator/helpers.swift
+++ b/Sources/TecoPackageGenerator/helpers.swift
@@ -15,10 +15,14 @@ func generateService(with generator: URL, manifest: URL, to directory: URL, erro
     let process = Process()
     process.executableURL = generator
 
+    let version = manifest.deletingLastPathComponent().lastPathComponent.dropFirst()
+    precondition(version.count == 8, "Invalid manifest version \(manifest.deletingLastPathComponent().lastPathComponent)")
+
     let arguments = {
         var arguments = [
             "--source=\(manifest.path)",
             "--output-dir=\(directory.path)",
+            "--version=\(version)",
         ]
         if let errorFile {
             arguments.append("--error-file=\(errorFile.path)")

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -11,7 +11,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
     @Option(name: .shortAndLong, completion: .file(extensions: ["json"]), transform: URL.init(fileURLWithPath:))
     var source: URL
-    
+
     @Option(name: .shortAndLong, completion: .file(extensions: ["json"]), transform: URL.init(fileURLWithPath:))
     var errorFile: URL?
 
@@ -20,6 +20,9 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
     @Flag
     var dryRun: Bool = false
+
+    @Option(name: .long)
+    var version: Int?
 
     func generate() throws {
         // Check for Regex support

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -194,3 +194,13 @@ struct TecoServiceGenerator: TecoCodeGenerator {
         }
     }
 }
+
+extension TecoServiceGenerator {
+    var startingYear: Int {
+        if let version {
+            precondition(version.signum() > 0 && "\(version)".count == 8, "Invalid manifest version")
+            return version / 10000
+        }
+        return Self.startingYear
+    }
+}


### PR DESCRIPTION
This PR adds a `--version` option to Teco service generator, allowing it to parse the service version and set the starting year according to it.