### PR TITLE
Fixes service initializer documentation

### DIFF
--- a/Sources/TecoServiceGenerator/builder.swift
+++ b/Sources/TecoServiceGenerator/builder.swift
@@ -93,6 +93,7 @@ func buildServiceInitializerDecl(with serviceMetadata: APIModel.Metadata, hasErr
         ///    - language: Preferred language for API response.
         ///    - endpoint: Endpoint provider for API request.
         ///    - timeout: Timeout value for HTTP requests.
+        ///    - byteBufferAllocator: Byte buffer allocator used throughout ``\(raw: serviceMetadata.shortName.upperFirst())``.
         public init(
             client: TCClient,
             region: TCRegion? = nil,


### PR DESCRIPTION
This PR adds the missing documentation for `byteBufferAllocator` in generated `client.swift` files by Teco service generators (see teco-project/teco#5).