### PR TITLE
Removes unnecessary `precondition` on model usage

### DIFF
--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -57,11 +57,10 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                 let requestResponseModelNames = Set(service.actions.map(\.value).flatMap { [$0.input, $0.output] })
                 for modelName in requestResponseModelNames {
                     precondition(ServiceContext.objects[modelName] != nil)
-                    precondition(ServiceContext.objects[modelName]?.usage == nil)
                     models.removeValue(forKey: modelName)
                 }
 
-                // Validate model fragments.
+                // Validate model components.
                 for model in models.values {
                     precondition(model.usage != nil)
                 }


### PR DESCRIPTION
The latest API model files mark the usage of some `Response` objects. This has no effect and we should remove the `precondition` check to unblock code generation.

https://github.com/teco-project/teco-api-models/blob/eae3f4d1085075d3f2bbc6d92e2aecdc1c62dc16/zh-CN/services/ckafka/v20190819/api.json#L15307