### PR TITLE
Implements generator support for wrapped response objects

### DIFF
--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -135,7 +135,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
 
                         try ExtensionDeclSyntax("extension \(raw: serviceName)") {
                             try buildRequestModelDecl(for: metadata.input, metadata: input, pagination: pagination, output: (metadata.output, output))
-                            try buildResponseModelDecl(for: metadata.output, metadata: output, paginated: pagination != nil)
+                            try buildResponseModelDecl(for: metadata.output, metadata: output, wrapped: false, paginated: pagination != nil)
 
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput)
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput, async: true)

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -51,12 +51,13 @@ func getSwiftMemberType(for model: APIObject.Member) -> String {
     return type
 }
 
-func publicLetWithWrapper(for member: APIObject.Member) -> String {
+func publicLetWithWrapper(for member: APIObject.Member, computed: Bool = false) -> String {
     guard member.type != .binary else {
         fatalError("Multipart APIs shouldn't be generated!")
     }
 
     if let dateType = member.dateType {
+        precondition(computed == false, "Computed date properties are not supported yet.")
         return """
             ///
             /// While the wrapped date value is immutable just like other fields, you can customize the projected
@@ -64,7 +65,7 @@ func publicLetWithWrapper(for member: APIObject.Member) -> String {
             @\(dateType.propertyWrapper) public var
             """
     } else {
-        return "public let"
+        return "public \(computed ? "var" : "let")"
     }
 }
 


### PR DESCRIPTION
Wrapped response objects define the nested `Data` as an object, and does not specify a request ID field.

This PR allows for generating such structure, with convenience helpers to keep API surface identical with other `TCResponseModel`s.