### PR TITLE
Fixes a bug when a member has name `init`

### DIFF
--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -114,7 +114,8 @@ func buildModelInitializerDeclSyntax(with members: [APIObject.Member]) throws ->
                     self.\(raw: "_\(member.identifier)") = .init(wrappedValue: \(raw: member.escapedIdentifier))
                     """)
             } else {
-                ExprSyntax("self.\(raw: member.identifier) = \(raw: member.escapedIdentifier)")
+                let identifier = member.identifier
+                ExprSyntax("self.\(raw: identifier == "init" ? "`init`" : identifier) = \(raw: member.escapedIdentifier)")
             }
         }
     }


### PR DESCRIPTION
Previously the generator outputs
```swift
self.init = `init`
```
in the initializer body, which cannot compile.

This PR corrects it to
```swift
self.`init` = `init`
```