### PR TITLE
Adds support for model member deprecations

### DIFF
--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import TecoCodeGeneratorCommons
 
-func buildModelMemberDeprecationAttribute(for members: [APIObject.Member], in model: String, functionNameBuilder: @escaping (String) -> String) -> AttributeSyntax? {
+func buildModelMemberDeprecationAttribute(for members: [APIObject.Member], in model: String? = nil, functionNameBuilder: @escaping (String) -> String) -> AttributeSyntax? {
     guard case let deprecated = members.filter(\.disabled),
           let message = deprecationMessage(for: deprecated.map(\.identifier), in: model) else {
         return nil
@@ -42,7 +42,7 @@ func buildDefaultArgument(for member: APIObject.Member) -> ExprSyntax? {
 }
 
 @FunctionParameterListBuilder
-func buildInitializerParameterList(for members: [APIObject.Member], includeDeprecated: Bool = true) -> FunctionParameterListSyntax {
+func buildInitializerParameterList(for members: [APIObject.Member], includeDeprecated: Bool = false) -> FunctionParameterListSyntax {
     for member in members where includeDeprecated || !member.disabled {
         FunctionParameterSyntax(
             firstName: "\(raw: member.identifier)",

--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -2,35 +2,53 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import TecoCodeGeneratorCommons
 
-func buildInitializerParameterList(for members: [APIObject.Member]) -> FunctionParameterListSyntax {
-    func getDefaultArgument(for member: APIObject.Member) -> ExprSyntax? {
-        let type = getSwiftType(for: member, isInitializer: true)
-        if let defaultValue = member.default, member.required {
-            if type == "String" {
-                return ExprSyntax(literal: defaultValue)
-            } else if type == "Bool" {
-                return ExprSyntax("\(raw: defaultValue.lowercased())")
-            } else if type == "Float" || type == "Double" || type.hasPrefix("Int") || type.hasPrefix("UInt") {
-                return ExprSyntax("\(raw: defaultValue)")
-            } else if type == "Date" {
-                fatalError("Default value support for Date not implemented yet!")
-            }
-        }
-        if !member.required {
-            return NilLiteralExprSyntax().as(ExprSyntax.self)
-        }
+func buildModelMemberDeprecationAttribute(for members: [APIObject.Member], in model: String, functionNameBuilder: @escaping (String) -> String) -> AttributeSyntax? {
+    guard case let deprecated = members.filter(\.disabled),
+          let message = deprecationMessage(for: deprecated.map(\.identifier), in: model) else {
         return nil
     }
+    let renamed = functionNameBuilder(members.filter({ !$0.disabled }).map({ "\($0.identifier):" }).joined())
+    let arguments = AvailabilityArgumentListSyntax {
+        AvailabilityArgumentSyntax(argument: .token(.binaryOperator("*")))
+        AvailabilityArgumentSyntax(argument: .token(.keyword(.deprecated)))
+        AvailabilityArgumentSyntax(argument: .availabilityLabeledArgument(.init(label: .keyword(.renamed), value: .string(.init(content: renamed)))))
+        AvailabilityArgumentSyntax(argument: .availabilityLabeledArgument(.init(label: .keyword(.message), value: .string(.init(content: message)))))
+    }
+    return AttributeSyntax(
+        attributeName: TypeSyntax("available"),
+        leftParen: .leftParenToken(),
+        arguments: .availability(arguments),
+        rightParen: .rightParenToken()
+    )
+}
 
-    return FunctionParameterListSyntax {
-        for member in members {
-            FunctionParameterSyntax(
-                firstName: "\(raw: member.identifier)",
-                colon: .colonToken(),
-                type: TypeSyntax("\(raw: getSwiftType(for: member, isInitializer: true))"),
-                defaultValue: getDefaultArgument(for: member).map { .init(value: $0) }
-            )
+func buildDefaultArgument(for member: APIObject.Member) -> ExprSyntax? {
+    let type = getSwiftType(for: member, isInitializer: true)
+    if let defaultValue = member.default, member.required {
+        if type == "String" {
+            return ExprSyntax(literal: defaultValue)
+        } else if type == "Bool" {
+            return ExprSyntax("\(raw: defaultValue.lowercased())")
+        } else if type == "Float" || type == "Double" || type.hasPrefix("Int") || type.hasPrefix("UInt") {
+            return ExprSyntax("\(raw: defaultValue)")
+        } else if type == "Date" {
+            fatalError("Default value support for Date not implemented yet!")
         }
+    }
+    if !member.required || !member.outputRequired {
+        return NilLiteralExprSyntax().as(ExprSyntax.self)
+    }
+    return nil
+}
+
+@FunctionParameterListBuilder
+func buildInitializerParameterList(for members: [APIObject.Member], includeDeprecated: Bool = true) -> FunctionParameterListSyntax {
+    for member in members where includeDeprecated || !member.disabled {
+        FunctionParameterSyntax(
+            firstName: "\(raw: member.identifier)",
+            type: TypeSyntax("\(raw: getSwiftType(for: member, isInitializer: true))"),
+            defaultValue: buildDefaultArgument(for: member).map { .init(value: $0) }
+        )
     }
 }
 
@@ -40,12 +58,9 @@ func buildRequestModelDecl(for input: String, metadata: APIObject, pagination: P
         public struct \(raw: input): \(raw: pagination != nil ? "TCPaginatedRequest" : "TCRequestModel")
         """) {
         let inputMembers = metadata.members.filter({ $0.type != .binary })
+        buildModelMemberList(for: input, usage: .in, members: inputMembers)
 
-        for member in inputMembers {
-            DeclSyntax("\(raw: publicLetWithWrapper(for: member, documentation: buildDocumentation(summary: member.document))) \(raw: member.escapedIdentifier): \(raw: getSwiftType(for: member))")
-        }
-
-        try buildModelInitializerDeclSyntax(with: inputMembers)
+        try buildModelInitializerDecls(for: input, members: inputMembers)
 
         try buildModelCodingKeys(for: inputMembers)
 
@@ -56,11 +71,26 @@ func buildRequestModelDecl(for input: String, metadata: APIObject, pagination: P
 }
 
 @MemberBlockItemListBuilder
-func buildResponseModelMemberList(for output: APIObject, documentation: Bool = true, wrapped: Bool = false) -> MemberBlockItemListSyntax {
-    for member in output.members {
-        let getter = AccessorBlockSyntax(accessors: .getter("self.data.\(raw: member.identifier)"))
-        let binding = PatternBindingSyntax(pattern: PatternSyntax("\(raw: member.escapedIdentifier)"), typeAnnotation: .init(type: TypeSyntax("\(raw: getSwiftType(for: member))")), accessorBlock: wrapped ? getter : nil)
-        DeclSyntax("\(raw: publicLetWithWrapper(for: member, documentation: documentation ? buildDocumentation(summary: member.document) : "", computed: wrapped)) \(binding)")
+func buildModelMemberList(for model: String, usage: APIObject.Usage?, members: [APIObject.Member], documentation: Bool = true, wrappedResponse: Bool = false) -> MemberBlockItemListSyntax {
+    for member in members {
+        let accessor = wrappedResponse ? AccessorBlockSyntax(accessors: .getter("self.data.\(raw: member.identifier)")) : nil
+        let initializer: InitializerClauseSyntax? = {
+            guard usage != .out, member.disabled else {
+                return nil
+            }
+            guard let defaultValue = buildDefaultArgument(for: member) else {
+                fatalError("Disabled member '\(member.identifier)' must have default value.")
+            }
+            return .init(value: defaultValue)
+        }()
+
+        let binding = PatternBindingSyntax(
+            pattern: PatternSyntax("\(raw: member.escapedIdentifier)"),
+            typeAnnotation: .init(type: TypeSyntax("\(raw: getSwiftType(for: member))")),
+            initializer: initializer,
+            accessorBlock: accessor
+        )
+        DeclSyntax("\(raw: publicLetWithWrapper(for: member, documentation: documentation ? buildDocumentation(summary: member.document) : "", computed: wrappedResponse, deprecated: member.disabled)) \(binding)")
     }
 }
 
@@ -74,11 +104,11 @@ func buildResponseModelDecl(for output: String, metadata: APIObject, wrapped: Bo
             DeclSyntax("private let data: Wrapped")
 
             try StructDeclSyntax("private struct Wrapped: Codable") {
-                buildResponseModelMemberList(for: metadata, documentation: false)
+                buildModelMemberList(for: output, usage: .out, members: metadata.members, documentation: false)
                 try buildModelCodingKeys(for: metadata.members)
             }
 
-            buildResponseModelMemberList(for: metadata, wrapped: true)
+            buildModelMemberList(for: output, usage: .out, members: metadata.members, wrappedResponse: true)
 
             DeclSyntax("""
                 /// 唯一请求 ID，每次请求都会返回。定位问题时需要提供该次请求的 RequestId。
@@ -92,7 +122,7 @@ func buildResponseModelDecl(for output: String, metadata: APIObject, wrapped: Bo
                 }
                 """)
         } else {
-            buildResponseModelMemberList(for: metadata)
+            buildModelMemberList(for: output, usage: .out, members: metadata.members)
             try buildModelCodingKeys(for: metadata.members)
         }
 
@@ -113,21 +143,27 @@ func buildGeneralModelDecl(for model: String, metadata: APIObject) throws -> Str
         """) {
         let members = metadata.members
 
-        for member in members {
-            DeclSyntax("\(raw: publicLetWithWrapper(for: member, documentation: buildDocumentation(summary: member.document))) \(raw: member.escapedIdentifier): \(raw: getSwiftType(for: member))")
-        }
+        buildModelMemberList(for: model, usage: metadata.usage, members: members)
 
         if metadata.initializable {
-            try buildModelInitializerDeclSyntax(with: members)
+            try buildModelInitializerDecls(for: model, members: members)
         }
 
         try buildModelCodingKeys(for: members)
     }
 }
 
-func buildModelInitializerDeclSyntax(with members: [APIObject.Member]) throws -> InitializerDeclSyntax {
-    try InitializerDeclSyntax("public init(\(buildInitializerParameterList(for: members)))") {
-        for member in members {
+@MemberBlockItemListBuilder
+func buildModelInitializerDecls(for model: String, members: [APIObject.Member]) throws -> MemberBlockItemListSyntax {
+    try buildModelInitializerDeclSyntax(for: model, members: members)
+    if members.contains(where: \.disabled) {
+        try buildModelInitializerDeclSyntax(for: model, members: members, deprecated: true)
+    }
+}
+
+func buildModelInitializerDeclSyntax(for model: String, members: [APIObject.Member], deprecated: Bool = false) throws -> InitializerDeclSyntax {
+    let decl = try InitializerDeclSyntax("public init(\(buildInitializerParameterList(for: members, includeDeprecated: deprecated)))") {
+        for member in members where !member.disabled {
             if member.dateType != nil {
                 ExprSyntax("""
                     self.\(raw: "_\(member.identifier)") = .init(wrappedValue: \(raw: member.escapedIdentifier))
@@ -137,6 +173,11 @@ func buildModelInitializerDeclSyntax(with members: [APIObject.Member]) throws ->
                 ExprSyntax("self.\(raw: identifier == "init" ? "`init`" : identifier) = \(raw: member.escapedIdentifier)")
             }
         }
+    }
+    if deprecated, let availability = buildModelMemberDeprecationAttribute(for: members, in: model, functionNameBuilder: { "init(\($0))" }) {
+        return decl.with(\.attributes, [.attribute(availability).with(\.trailingTrivia, .newline)])
+    } else {
+        return decl
     }
 }
 

--- a/Sources/TecoServiceGenerator/builders/Pagination.swift
+++ b/Sources/TecoServiceGenerator/builders/Pagination.swift
@@ -33,6 +33,7 @@ func buildMakeNextRequestDecl(for pagination: Pagination, input: (name: String, 
 }
 
 private func buildNextInputExpr(for type: String, members: [APIObject.Member], kind: Pagination) -> ExprSyntax {
+    let members = members.filter({ !$0.disabled })
     var parameters = OrderedDictionary(members.map({ ($0.identifier, "self.\($0.identifier)") }), uniquingKeysWith: { $1 })
     switch kind {
     case .token(let input, let output):

--- a/Sources/TecoServiceGenerator/builders/Pagination.swift
+++ b/Sources/TecoServiceGenerator/builders/Pagination.swift
@@ -6,7 +6,7 @@ func buildGetItemsDecl(with field: APIObject.Field) -> DeclSyntax {
     DeclSyntax("""
         /// Extract the returned item list from the paginated response.
         public func getItems() -> [\(raw: getSwiftMemberType(for: field.metadata))] {
-            self.\(raw: field.key)\(raw: field.metadata.nullable || field.key.contains("?") ? " ?? []" : "")
+            self.\(raw: field.key)\(raw: field.metadata.optional || field.key.contains("?") ? " ?? []" : "")
         }
         """)
 }

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -142,8 +142,8 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput)
                             try buildActionDecl(for: action, metadata: metadata, discardable: discardableOutput, async: true)
 
-                            try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput)
-                            try buildActionDecl(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput, async: true)
+                            try buildUnpackedActionDecls(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput)
+                            try buildUnpackedActionDecls(for: action, metadata: metadata, unpacking: inputMembers, discardable: discardableOutput, async: true)
 
                             if pagination != nil {
                                 try buildPaginatedActionDecl(for: action, metadata: metadata, output: output)

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -9,7 +9,7 @@ func getSwiftType(for model: APIObject.Member, isInitializer: Bool = false, forc
     }
 
     if model.optional || forceOptional {
-        if !forceOptional, isInitializer, model.required {
+        if !forceOptional, isInitializer, model.required && model.outputRequired {
             // We regard required nullable fields as **required** for input and **nullable** in output,
             // so use non-optional for initializer.
             return type

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -51,7 +51,7 @@ func getSwiftMemberType(for model: APIObject.Member) -> String {
     return type
 }
 
-func publicLetWithWrapper(for member: APIObject.Member, documentation: String = "", computed: Bool = false) -> String {
+func publicLetWithWrapper(for member: APIObject.Member, documentation: String = "", computed: Bool = false, deprecated: Bool = false) -> String {
     guard member.type != .binary else {
         fatalError("Multipart APIs shouldn't be generated!")
     }
@@ -59,6 +59,7 @@ func publicLetWithWrapper(for member: APIObject.Member, documentation: String = 
     if documentation.last?.isNewline == false {
         documentation += "\n"
     }
+    let availablility = deprecated ? "@available(*, deprecated)\n" : ""
 
     if let dateType = member.dateType {
         precondition(computed == false, "Computed date properties are not supported yet.")
@@ -68,12 +69,34 @@ func publicLetWithWrapper(for member: APIObject.Member, documentation: String = 
         return """
             \(documentation)/// While the wrapped date value is immutable just like other fields, you can customize the projected
             /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
-            @\(dateType.propertyWrapper) public var
+            \(availablility)@\(dateType.propertyWrapper) public var
             """
     } else {
-        return "\(documentation)public \(computed ? "var" : "let")"
+        return "\(documentation)\(availablility)public \(computed ? "var" : "let")"
     }
 }
+
+func deprecationMessage(for members: [String], in object: String? = nil) -> String? {
+    let deprecated = {
+        if let object {
+            return "deprecated in '\(object)'"
+        } else {
+            return "deprecated"
+        }
+    }()
+
+    guard members.count > 1 else {
+        if members.count == 1 {
+            return "'\(members[0])' is \(deprecated). Setting this parameter has no effect."
+        }
+        return nil
+    }
+
+    var list = members.map({ "'\($0)'" })
+    let last = list.removeLast()
+    return "\(list.joined(separator: ", ")) and \(last) are \(deprecated). Setting these parameters has no effect."
+}
+
 
 extension APIObject {
     var protocols: [String] {

--- a/Sources/TecoServiceGenerator/models/APIObject.swift
+++ b/Sources/TecoServiceGenerator/models/APIObject.swift
@@ -22,9 +22,11 @@ struct APIObject: Codable {
     }
 
     struct Member: Codable {
+        private let _disabled: Bool?
         private let _default: String?
         let name: String
         private let _required: Bool?
+        private let _output_required: Bool?
         private let _nullable: Bool?
         private let _document: String
         let example: String?
@@ -32,9 +34,11 @@ struct APIObject: Codable {
         let type: APIObject.`Type`
 
         var document: String { self._document == "无" ? "" : self._document }
+        var disabled: Bool { self._disabled ?? false }
         var required: Bool { self._required ?? true }
+        var outputRequired: Bool { self._output_required ?? true }
         var nullable: Bool { self._nullable ?? false }
-        var optional: Bool { !self.required || self.nullable }
+        var optional: Bool { !self.required || !self.outputRequired || self.nullable }
 
         var `default`: String? {
             switch self._default {
@@ -49,9 +53,11 @@ struct APIObject: Codable {
         }
 
         enum CodingKeys: String, CodingKey {
+            case _disabled = "disabled"
             case _default = "default"
             case name
             case _required = "required"
+            case _output_required = "output_required"
             case _nullable = "value_allowed_null"
             case _document = "document"
             case example


### PR DESCRIPTION
Latest API models include flags to track if a member is "disabled". For backend-only models, disabled members are simply marked as deprecated; for constructible models, deprecated members are forced to default value, and the original initializer will also be marked as deprecated.

This PR also improves `TecoPackageGenerator` output style for better debugging experience, and unifies more implementation detail within `TecoServiceGenerator`.