### PR TITLE
Improves documentation style of pagination helpers

### DIFF
--- a/Sources/TecoServiceGenerator/builders/Action.swift
+++ b/Sources/TecoServiceGenerator/builders/Action.swift
@@ -138,7 +138,7 @@ func buildActionPaginatorDecl(for action: String, metadata: APIModel.Action, out
     try FunctionDeclSyntax("""
         \(raw: buildDocumentation(summary: metadata.name, discussion: metadata.document))
         ///
-        /// - Returns: `AsyncSequence`s of `\(raw: output.itemType!)` and `\(raw: metadata.output)` that can be iterated over asynchronously on demand.
+        /// - Returns: `AsyncSequence`s of ``\(raw: output.itemType!)`` and ``\(raw: metadata.output)`` that can be iterated over asynchronously on demand.
         \(buildActionAttributeList(for: metadata, discardableResult: false))
         public func \(raw: action.lowerFirst())Paginator\(buildActionParameterList(for: metadata)) -> TCClient.PaginatorSequences<\(raw: metadata.input)>
         """) {

--- a/Sources/TecoServiceGenerator/builders/Pagination.swift
+++ b/Sources/TecoServiceGenerator/builders/Pagination.swift
@@ -3,9 +3,10 @@ import SwiftSyntaxBuilder
 @_implementationOnly import OrderedCollections
 
 func buildGetItemsDecl(with field: APIObject.Field) -> DeclSyntax {
-    DeclSyntax("""
-        /// Extract the returned item list from the paginated response.
-        public func getItems() -> [\(raw: getSwiftMemberType(for: field.metadata))] {
+    let memberType = getSwiftMemberType(for: field.metadata)
+    return DeclSyntax("""
+        /// Extract the returned ``\(raw: memberType)`` list from the paginated response.
+        public func getItems() -> [\(raw: memberType)] {
             self.\(raw: field.key)\(raw: field.metadata.optional || field.key.contains("?") ? " ?? []" : "")
         }
         """)


### PR DESCRIPTION
This PR generates documentation links to item and response types in the inline documentation of `getItem` and paginator helpers.