### PR TITLE
Improves line breaking in documentation generation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "teco-code-generators",
-    platforms: [.macOS(.v12)],
+    platforms: [.macOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .executable(

--- a/Sources/TecoServiceGenerator/helpers/ErrorHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ErrorHelpers.swift
@@ -45,8 +45,7 @@ func generateDomainedErrorMap(from errors: [APIError], for domain: String) -> Or
     return errorMap
 }
 
-@available(macOS 13, *)
-func formatErrorDescription(_ description: String) -> String {
+func formatErrorDescription(_ description: String?) -> String? {
     let codeTagRegex = Regex {
         "<code>"
         Capture(OneOrMore(.any, .reluctant))
@@ -59,7 +58,7 @@ func formatErrorDescription(_ description: String) -> String {
         Capture(OneOrMore(.any, .reluctant))
         "</a>"
     }
-    return description
+    return description?
         .replacing(codeTagRegex) { match in
             "`\(match.1)`"
         }

--- a/Sources/TecoServiceGenerator/helpers/ErrorHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ErrorHelpers.swift
@@ -1,5 +1,5 @@
 @_implementationOnly import OrderedCollections
-import RegexBuilder
+@_implementationOnly import RegexBuilder
 
 func getErrorDomain(from code: String) -> String? {
     let components = code.split(separator: ".")
@@ -66,4 +66,3 @@ func formatErrorDescription(_ description: String?) -> String? {
             "[\(match.2)](\(match.1))"
         }
 }
-

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import RegexBuilder
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
@@ -95,6 +96,39 @@ func deprecationMessage(for members: [String], in object: String? = nil) -> Stri
     var list = members.map({ "'\($0)'" })
     let last = list.removeLast()
     return "\(list.joined(separator: ", ")) and \(last) are \(deprecated). Setting these parameters has no effect."
+}
+
+func formatModelDocumentation(_ documentation: String?) -> String? {
+    guard let documentation, !documentation.isEmpty, documentation != "无" else {
+        return nil
+    }
+
+    let lineBreakRegex = Regex {
+        ZeroOrMore {
+            ZeroOrMore(.whitespace)
+            One(.newlineSequence)
+        }
+        ChoiceOf {
+            Repeat(count: 2) {
+                ZeroOrMore(.whitespace)
+                One(.newlineSequence)
+            }
+            OneOrMore {
+                ZeroOrMore(.whitespace)
+                "<br"
+                ZeroOrMore(.whitespace)
+                Optionally("/")
+                ">"
+            }
+        }
+        ZeroOrMore {
+            ChoiceOf {
+                One(.newlineSequence)
+                One(.whitespace)
+            }
+        }
+    }
+    return documentation.replacing(lineBreakRegex, with: { _ in "\n\n" })
 }
 
 

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -103,32 +103,30 @@ func formatModelDocumentation(_ documentation: String?) -> String? {
         return nil
     }
 
-    let lineBreakRegex = Regex {
+    let brTagsWithNewlinesAndWhitespacesRegex = Regex {
+        ZeroOrMore {
+            One(.newlineSequence)
+            ZeroOrMore(.whitespace)
+        }
+        OneOrMore {
+            "<br"
+            ZeroOrMore(.whitespace)
+            Optionally("/")
+            ">"
+            ZeroOrMore(.whitespace)
+        }
         ZeroOrMore {
             ZeroOrMore(.whitespace)
             One(.newlineSequence)
         }
-        ChoiceOf {
-            Repeat(count: 2) {
-                ZeroOrMore(.whitespace)
-                One(.newlineSequence)
-            }
-            OneOrMore {
-                ZeroOrMore(.whitespace)
-                "<br"
-                ZeroOrMore(.whitespace)
-                Optionally("/")
-                ">"
-            }
-        }
-        ZeroOrMore {
-            ChoiceOf {
-                One(.newlineSequence)
-                One(.whitespace)
-            }
-        }
     }
-    return documentation.replacing(lineBreakRegex, with: { _ in "\n\n" })
+    let threeOrMoreNewlinesRegex = Regex {
+        Repeat(.newlineSequence, count: 3)
+        ZeroOrMore(.newlineSequence)
+    }
+    return documentation
+        .replacing(brTagsWithNewlinesAndWhitespacesRegex, with: { _ in "\n\n" })
+        .replacing(threeOrMoreNewlinesRegex, with: { _ in "\n\n" })
 }
 
 

--- a/Sources/TecoServiceGenerator/models/APIError.swift
+++ b/Sources/TecoServiceGenerator/models/APIError.swift
@@ -6,14 +6,7 @@ struct APIError: Codable {
     private let _solution: String
     let productCNName: String?
 
-    var description: String? {
-        if #available(macOS 13, *) {
-            return self._description.map(formatErrorDescription)
-        } else {
-            // documentation style may be ugly since this platform doesn't support Regex...
-            return self._description
-        }
-    }
+    var description: String? { formatErrorDescription(self._description) }
 
     var solution: String? {
         switch self._solution {

--- a/Sources/TecoServiceGenerator/models/APIModel.swift
+++ b/Sources/TecoServiceGenerator/models/APIModel.swift
@@ -34,13 +34,10 @@ struct APIModel: Codable {
         }
 
         var deprecationMessage: String? {
-            guard self.status != .online else { return nil }
-            if #available(macOS 13, *) {
-                return self._document.split(separator: "\n\n").first.map(String.init)
-            } else {
-                // message may be stripped since this platform doesn't support Regex...
-                return self._document.split(whereSeparator: \.isNewline).first.map(String.init)
+            guard self.status != .online else {
+                return nil
             }
+            return self._document.split(separator: "\n\n").first.map(String.init)
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/TecoServiceGenerator/models/APIObject.swift
+++ b/Sources/TecoServiceGenerator/models/APIObject.swift
@@ -4,7 +4,7 @@ struct APIObject: Codable {
     private let _type: `Type`?
     var usage: Usage?
 
-    var document: String { self._document == "无" ? "" : self._document }
+    var document: String? { formatModelDocumentation(self._document) }
     var type: `Type` { self._type ?? .object }
     var initializable: Bool { self.usage == .in || self.usage == .both }
 
@@ -33,7 +33,7 @@ struct APIObject: Codable {
         let member: String
         let type: APIObject.`Type`
 
-        var document: String { self._document == "无" ? "" : self._document }
+        var document: String? { formatModelDocumentation(self._document) }
         var disabled: Bool { self._disabled ?? false }
         var required: Bool { self._required ?? true }
         var outputRequired: Bool { self._output_required ?? true }


### PR DESCRIPTION
This PR adds support for converting HTML tag `<br>` to Markdown paragraph break `\n\n` in model documentation. It also removes extra blank lines from documentation, and bumps macOS requirement to 13+ for Regex support.