### PR TITLE
Transforms HTML in documentation to DocC-supported Markdown

### DIFF
--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -66,6 +66,35 @@ func formatDocumentation(_ documentation: String?) -> String? {
         documentation.replace(unclosedDivTagRegex, with: \.1)
     }
 
+    // Convert <code> to code block
+    do {
+        let codeTagRegex = Regex {
+            Capture {
+                ZeroOrMore(newlineAndWhitespaceRegex)
+            }
+            "<code>"
+            Capture {
+                ZeroOrMore(.any)
+            }
+            "</code>"
+        }
+        documentation.replace(codeTagRegex) { match in
+            let leadingBlank = match.1
+            let code = match.2.trimmingCharacters(in: .whitespacesAndNewlines)
+            if code.contains(where: \.isNewline) || leadingBlank.contains(where: \.isNewline) {
+                return """
+                
+                ```
+                \(code)
+                ```
+                
+                """
+            } else {
+                return "\(leadingBlank)`\(match.2)`"
+            }
+        }
+    }
+
     // Convert <b> and <strong> to **bold**
     do {
         let bTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -149,6 +149,23 @@ func formatDocumentation(_ documentation: String?) -> String? {
         documentation.replace(preTagRegex, with: \.1)
     }
 
+    // Strip <span> tags
+    do {
+        let spanTagRegex = Regex {
+            htmlOpeningTagRegex(for: "span")
+            Capture {
+                ZeroOrMore(.any, .reluctant)
+            }
+            htmlClosingTagRegex(for: "span")
+        }
+        // Do this one by one to handle nested <span>
+        while let match = documentation.firstMatch(of: spanTagRegex) {
+            documentation.replaceSubrange(match.range, with: match.1)
+        }
+        // Handle unclosed <span> tags
+        documentation.replace(htmlOpeningTagRegex(for: "span"), with: "")
+    }
+
     // Convert <br> to new paragraph
     do {
         let brTagsWithTrailingWhitespacesRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -260,6 +260,27 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
     }
 
+    // Remove extra "\n>\n" sequence
+    do {
+        let unwantedAngleRegex = Regex {
+            One(.newlineSequence)
+            ">"
+            ZeroOrMore(.whitespace, .reluctant)
+            One(.newlineSequence)
+        }
+        let documentationCopy = documentation
+        documentation.replace(unwantedAngleRegex) { match in
+            guard match.endIndex < documentationCopy.endIndex, documentationCopy[match.endIndex] == ">" else {
+                if documentationCopy[documentationCopy.index(before: match.startIndex)].isNewline {
+                    return ""
+                } else {
+                    return "\n"
+                }
+            }
+            return .init(match.output)
+        }
+    }
+
     // Merge three or more newlines to two
     do {
         let threeOrMoreNewlinesRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -224,7 +224,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ">"
             Optionally("[")
             Capture {
-                OneOrMore(.any, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             Optionally("]")
             "</a>"
@@ -324,7 +324,9 @@ func formatDocumentation(_ documentation: String?) -> String? {
     // Convert <table> to GFM table
     do {
         let tableTagRegex = Regex {
-            "<table>"
+            "<table"
+            ZeroOrMore(.any, .reluctant)
+            ">"
             Capture {
                 ZeroOrMore(.any, .reluctant)
             }

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -23,21 +23,11 @@ func formatDocumentation(_ documentation: String?) -> String? {
     // Convert <br> to new paragraph
     do {
         let brTagsWithNewlinesAndWhitespacesRegex = Regex {
-            ZeroOrMore {
-                One(.newlineSequence)
-                ZeroOrMore(.whitespace)
-            }
-            OneOrMore {
-                "<br"
-                ZeroOrMore(.whitespace)
-                Optionally("/")
-                ">"
-                ZeroOrMore(.whitespace)
-            }
-            ZeroOrMore {
-                ZeroOrMore(.whitespace)
-                One(.newlineSequence)
-            }
+            "<br"
+            ZeroOrMore(.whitespace)
+            Optionally("/")
+            ">"
+            ZeroOrMore(.whitespace)
         }
         documentation.replace(brTagsWithNewlinesAndWhitespacesRegex) { _ in "\n\n" }
     }
@@ -90,12 +80,13 @@ func formatDocumentation(_ documentation: String?) -> String? {
     // Merge three or more newlines to two
     do {
         let threeOrMoreNewlinesRegex = Regex {
-            Repeat(.newlineSequence, count: 3)
-            ZeroOrMore(.newlineSequence)
+            One(.newlineSequence)
+            Repeat(2...) {
+                ZeroOrMore(.whitespace)
+                One(.newlineSequence)
+            }
         }
         documentation.replace(threeOrMoreNewlinesRegex) { _ in "\n\n" }
     }
     return documentation.trimmingCharacters(in: .whitespacesAndNewlines)
 }
-
-

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -39,18 +39,24 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ZeroOrMore(.any, .reluctant)
             ">"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
+            "</div>"
+        }
+        let unclosedDivTagRegex = Regex {
+            "<div"
+            ZeroOrMore(.any, .reluctant)
+            ">"
             Capture {
-                ChoiceOf {
-                    "</div>"
-                    One(.newlineSequence)
-                }
+                ZeroOrMore(.anyNonNewline)
+                One(.newlineSequence)
             }
         }
-        documentation.replace(divTagRegex) { match in
-            match.2 == "</div>" ? match.1 : "\(match.1)\n"
+        // Do this one by one to handle nested <div>
+        while let match = documentation.firstMatch(of: divTagRegex) {
+            documentation.replaceSubrange(match.range, with: match.1)
         }
+        documentation.replace(unclosedDivTagRegex, with: \.1)
     }
 
     // Convert <b> and <strong> to **bold**

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -226,6 +226,28 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
     }
 
+    // Convert <h1> - <h5> to #
+    do {
+        let hTagRegex = Regex {
+            "<h"
+            Capture(.digit)
+            ZeroOrMore(.any, .reluctant)
+            ">"
+            Capture {
+                ZeroOrMore(.any, .reluctant)
+            }
+            "</h"
+            One(.digit)
+            ">"
+        }
+        documentation.replace(hTagRegex) { match in
+            guard let level = Int(match.1), (1...5).contains(level) else {
+                fatalError("Invalid header level <h\(match.1)>")
+            }
+            return "\n\(String(repeating: "#", count: level)) \(match.2)\n"
+        }
+    }
+
     // Convert `>?` to attention block
     do {
         let attentionMarkRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import RegexBuilder
 import SwiftSyntax
 
 enum ServiceContext {
@@ -9,3 +10,92 @@ func skipAuthorizationParameter(for action: String) -> String {
     // Special rule for sts:AssumeRoleWithSAML & sts:AssumeRoleWithWebIdentity
     return action.hasPrefix("AssumeRoleWith") ? ", skipAuthorization: true" : ""
 }
+
+func formatDocumentation(_ documentation: Substring?) -> String? {
+    formatDocumentation(documentation.map(String.init))
+}
+
+func formatDocumentation(_ documentation: String?) -> String? {
+    guard var documentation, !documentation.isEmpty, documentation != "无" else {
+        return nil
+    }
+
+    // Convert <br> to new paragraph
+    do {
+        let brTagsWithNewlinesAndWhitespacesRegex = Regex {
+            ZeroOrMore {
+                One(.newlineSequence)
+                ZeroOrMore(.whitespace)
+            }
+            OneOrMore {
+                "<br"
+                ZeroOrMore(.whitespace)
+                Optionally("/")
+                ">"
+                ZeroOrMore(.whitespace)
+            }
+            ZeroOrMore {
+                ZeroOrMore(.whitespace)
+                One(.newlineSequence)
+            }
+        }
+        documentation.replace(brTagsWithNewlinesAndWhitespacesRegex) { _ in "\n\n" }
+    }
+
+    // Strip <div> tags
+    do {
+        let divTagRegex = Regex {
+            "<div"
+            ZeroOrMore(.any, .reluctant)
+            ">"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            Capture {
+                ChoiceOf {
+                    "</div>"
+                    One(.newlineSequence)
+                }
+            }
+        }
+        documentation.replace(divTagRegex) { match in
+            match.2 == "</div>" ? match.1 : "\(match.1)\n"
+        }
+    }
+
+    // Convert <b> and <strong> to **bold**
+    do {
+        let bTagRegex = Regex {
+            "<b>"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            "</b>"
+        }
+        let strongTagRegex = Regex {
+            "<strong>"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            "</strong>"
+        }
+        for tagRegex in [bTagRegex, strongTagRegex] {
+            documentation.replace(tagRegex) { match in
+                let content = match.1
+                return content.isEmpty ? "" : "**\(content)**"
+            }
+        }
+    }
+
+    // Merge three or more newlines to two
+    do {
+        let threeOrMoreNewlinesRegex = Regex {
+            Repeat(.newlineSequence, count: 3)
+            ZeroOrMore(.newlineSequence)
+        }
+        documentation.replace(threeOrMoreNewlinesRegex) { _ in "\n\n" }
+    }
+    return documentation.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -28,9 +28,16 @@ func formatDocumentation(_ documentation: String?) -> String? {
     // Convert <br> to new paragraph
     do {
         let brTagsWithTrailingWhitespacesRegex = Regex {
-            "<br"
-            ZeroOrMore(.whitespace)
-            Optionally("/")
+            "<"
+            ChoiceOf {
+                Regex {
+                    "br"
+                    ZeroOrMore(.whitespace)
+                    Optionally("/")
+                }
+                // Special handling for typo...
+                "/br"
+            }
             ">"
             ZeroOrMore(.whitespace)
         }

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -20,16 +20,21 @@ func formatDocumentation(_ documentation: String?) -> String? {
         return nil
     }
 
+    let newlineAndWhitespaceRegex = ChoiceOf {
+        One(.newlineSequence)
+        One(.whitespace)
+    }
+
     // Convert <br> to new paragraph
     do {
-        let brTagsWithNewlinesAndWhitespacesRegex = Regex {
+        let brTagsWithTrailingWhitespacesRegex = Regex {
             "<br"
             ZeroOrMore(.whitespace)
             Optionally("/")
             ">"
             ZeroOrMore(.whitespace)
         }
-        documentation.replace(brTagsWithNewlinesAndWhitespacesRegex) { _ in "\n\n" }
+        documentation.replace(brTagsWithTrailingWhitespacesRegex) { _ in "\n\n" }
     }
 
     // Strip <div> tags
@@ -38,9 +43,11 @@ func formatDocumentation(_ documentation: String?) -> String? {
             "<div"
             ZeroOrMore(.any, .reluctant)
             ">"
+            ZeroOrMore(newlineAndWhitespaceRegex)
             Capture {
                 ZeroOrMore(.any, .reluctant)
             }
+            ZeroOrMore(newlineAndWhitespaceRegex)
             "</div>"
         }
         let unclosedDivTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -107,6 +107,20 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
     }
 
+    // Convert <del> to ~~deleted~~
+    do {
+        let delTagRegex = Regex {
+            "<del>"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            "</del>"
+        }
+        documentation.replace(delTagRegex) { match in
+            match.1.isEmpty ? "" : "~~\(match.1)~~"
+        }
+    }
+
     // Convert <font> to _italic_
     do {
         let fontTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -15,6 +15,10 @@ func formatDocumentation(_ documentation: Substring?) -> String? {
     formatDocumentation(documentation.map(String.init))
 }
 
+func zipMarkdownLine(_ text: Substring) -> Substring {
+    text.replacing(.newlineSequence, with: " ")
+}
+
 func formatDocumentation(_ documentation: String?) -> String? {
     guard var documentation, !documentation.isEmpty, documentation != "无" else {
         return nil
@@ -82,7 +86,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ">"
             ZeroOrMore(.whitespace)
         }
-        documentation.replace(brTagsWithTrailingWhitespacesRegex) { _ in "\n\n" }
+        documentation.replace(brTagsWithTrailingWhitespacesRegex, with: "\n\n")
     }
 
     // Convert <ul> and <li> to list
@@ -227,7 +231,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             if match.1.isEmpty || match.1.hasPrefix("#") {
                 return String(match.2)
             }
-            return "[\(match.2)](\(match.1))"
+            return "[\(zipMarkdownLine(match.2))](\(match.1))"
         }
     }
 
@@ -236,12 +240,12 @@ func formatDocumentation(_ documentation: String?) -> String? {
         let delTagRegex = Regex {
             "<del>"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             "</del>"
         }
         documentation.replace(delTagRegex) { match in
-            match.1.isEmpty ? "" : "~~\(match.1)~~"
+            match.1.isEmpty ? "" : "~~\(zipMarkdownLine(match.1))~~"
         }
     }
 
@@ -254,7 +258,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             }
             ">"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             "</font>"
         }
@@ -263,7 +267,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             guard match.1.contains("color="), !match.2.isEmpty else {
                 return match.2
             }
-            return "_\(match.2)_"
+            return "_\(zipMarkdownLine(match.2))_"
         }
     }
 
@@ -272,20 +276,20 @@ func formatDocumentation(_ documentation: String?) -> String? {
         let bTagRegex = Regex {
             "<b>"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             "</b>"
         }
         let strongTagRegex = Regex {
             "<strong>"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             "</strong>"
         }
         for tagRegex in [bTagRegex, strongTagRegex] {
             documentation.replace(tagRegex) { match in
-                match.1.isEmpty ? "" : "**\(match.1)**"
+                match.1.isEmpty ? "" : "**\(zipMarkdownLine(match.1))**"
             }
         }
     }
@@ -298,7 +302,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ZeroOrMore(.any, .reluctant)
             ">"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             "</h"
             One(.digit)
@@ -308,7 +312,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             guard let level = Int(match.1), (1...5).contains(level) else {
                 fatalError("Invalid header level <h\(match.1)>")
             }
-            return "\n\(String(repeating: "#", count: level)) \(match.2)\n"
+            return "\n\(String(repeating: "#", count: level)) \(zipMarkdownLine(match.2))\n"
         }
     }
 
@@ -496,7 +500,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
                 One(.newlineSequence)
             }
         }
-        documentation.replace(threeOrMoreNewlinesRegex) { _ in "\n\n" }
+        documentation.replace(threeOrMoreNewlinesRegex, with: "\n\n")
     }
     return documentation.trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -66,6 +66,18 @@ func formatDocumentation(_ documentation: String?) -> String? {
         documentation.replace(unclosedDivTagRegex, with: \.1)
     }
 
+    // Strip <pre> tags
+    do {
+        let preTagRegex = Regex {
+            "<pre>"
+            Capture {
+                ZeroOrMore(.any, .reluctant)
+            }
+            "</pre>"
+        }
+        documentation.replace(preTagRegex, with: \.1)
+    }
+
     // Convert <code> to code block
     do {
         let codeTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -92,7 +92,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ZeroOrMore(.any, .reluctant)
             "href=\""
             Capture {
-                OneOrMore(.any, .reluctant)
+                OneOrMore(.anyNonNewline, .reluctant)
             }
             "\""
             ZeroOrMore(.any, .reluctant)
@@ -123,7 +123,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             }
             "<code>"
             Capture {
-                ZeroOrMore(.any)
+                ZeroOrMore(.any, .reluctant)
             }
             "</code>"
         }
@@ -186,7 +186,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
         let fontTagRegex = Regex {
             "<font"
             Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
+                ZeroOrMore(.any, .reluctant)
             }
             ">"
             Capture {
@@ -234,7 +234,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             ZeroOrMore(.any, .reluctant)
             ">"
             Capture {
-                ZeroOrMore(.any, .reluctant)
+                ZeroOrMore(.anyNonNewline, .reluctant)
             }
             "</h"
             One(.digit)

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -107,6 +107,28 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
     }
 
+    // Convert <font> to _italic_
+    do {
+        let fontTagRegex = Regex {
+            "<font"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            ">"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            "</font>"
+        }
+        documentation.replace(fontTagRegex) { match in
+            // Only apply style if there's attribute on <font>
+            guard !match.1.allSatisfy(\.isWhitespace), !match.2.isEmpty else {
+                return match.2
+            }
+            return "_\(match.2)_"
+        }
+    }
+
     // Convert <b> and <strong> to **bold**
     do {
         let bTagRegex = Regex {
@@ -125,8 +147,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
         for tagRegex in [bTagRegex, strongTagRegex] {
             documentation.replace(tagRegex) { match in
-                let content = match.1
-                return content.isEmpty ? "" : "**\(content)**"
+                match.1.isEmpty ? "" : "**\(match.1)**"
             }
         }
     }

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -85,6 +85,36 @@ func formatDocumentation(_ documentation: String?) -> String? {
         documentation.replace(preTagRegex, with: \.1)
     }
 
+    // Convert <a> to [text](link)
+    do {
+        let aTagRegex = Regex {
+            "<a "
+            ZeroOrMore(.any, .reluctant)
+            "href=\""
+            Capture {
+                OneOrMore(.any, .reluctant)
+            }
+            "\""
+            ZeroOrMore(.any, .reluctant)
+            ">"
+            Optionally("[")
+            Capture {
+                OneOrMore(.any, .reluctant)
+            }
+            Optionally("]")
+            "</a>"
+        }
+        documentation.replace(aTagRegex) { match in
+            if match.2.isEmpty {
+                return ""
+            }
+            if match.1.isEmpty || match.1.hasPrefix("#") {
+                return String(match.2)
+            }
+            return "[\(match.2)](\(match.1))"
+        }
+    }
+
     // Convert <code> to code block
     do {
         let codeTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -125,6 +125,27 @@ func formatModelDocumentation(_ documentation: String?) -> String? {
         documentation.replace(brTagsWithNewlinesAndWhitespacesRegex) { _ in "\n\n" }
     }
 
+    // Strip <div> tags
+    do {
+        let divTagRegex = Regex {
+            "<div"
+            ZeroOrMore(.any, .reluctant)
+            ">"
+            Capture {
+                ZeroOrMore(.anyNonNewline, .reluctant)
+            }
+            Capture {
+                ChoiceOf {
+                    "</div>"
+                    One(.newlineSequence)
+                }
+            }
+        }
+        documentation.replace(divTagRegex) { match in
+            match.2 == "</div>" ? match.1 : "\(match.1)\n"
+        }
+    }
+
     // Convert <b> and <strong> to **bold**
     do {
         let bTagRegex = Regex {

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import RegexBuilder
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
@@ -96,89 +95,6 @@ func deprecationMessage(for members: [String], in object: String? = nil) -> Stri
     var list = members.map({ "'\($0)'" })
     let last = list.removeLast()
     return "\(list.joined(separator: ", ")) and \(last) are \(deprecated). Setting these parameters has no effect."
-}
-
-func formatModelDocumentation(_ documentation: String?) -> String? {
-    guard var documentation, !documentation.isEmpty, documentation != "无" else {
-        return nil
-    }
-
-    // Convert <br> to new paragraph
-    do {
-        let brTagsWithNewlinesAndWhitespacesRegex = Regex {
-            ZeroOrMore {
-                One(.newlineSequence)
-                ZeroOrMore(.whitespace)
-            }
-            OneOrMore {
-                "<br"
-                ZeroOrMore(.whitespace)
-                Optionally("/")
-                ">"
-                ZeroOrMore(.whitespace)
-            }
-            ZeroOrMore {
-                ZeroOrMore(.whitespace)
-                One(.newlineSequence)
-            }
-        }
-        documentation.replace(brTagsWithNewlinesAndWhitespacesRegex) { _ in "\n\n" }
-    }
-
-    // Strip <div> tags
-    do {
-        let divTagRegex = Regex {
-            "<div"
-            ZeroOrMore(.any, .reluctant)
-            ">"
-            Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
-            }
-            Capture {
-                ChoiceOf {
-                    "</div>"
-                    One(.newlineSequence)
-                }
-            }
-        }
-        documentation.replace(divTagRegex) { match in
-            match.2 == "</div>" ? match.1 : "\(match.1)\n"
-        }
-    }
-
-    // Convert <b> and <strong> to **bold**
-    do {
-        let bTagRegex = Regex {
-            "<b>"
-            Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
-            }
-            "</b>"
-        }
-        let strongTagRegex = Regex {
-            "<strong>"
-            Capture {
-                ZeroOrMore(.anyNonNewline, .reluctant)
-            }
-            "</strong>"
-        }
-        for tagRegex in [bTagRegex, strongTagRegex] {
-            documentation.replace(tagRegex) { match in
-                let content = match.1
-                return content.isEmpty ? "" : "**\(content)**"
-            }
-        }
-    }
-
-    // Merge three or more newlines to two
-    do {
-        let threeOrMoreNewlinesRegex = Regex {
-            Repeat(.newlineSequence, count: 3)
-            ZeroOrMore(.newlineSequence)
-        }
-        documentation.replace(threeOrMoreNewlinesRegex) { _ in "\n\n" }
-    }
-    return documentation.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 

--- a/Sources/TecoServiceGenerator/models/APIModel.swift
+++ b/Sources/TecoServiceGenerator/models/APIModel.swift
@@ -25,11 +25,11 @@ struct APIModel: Codable {
             }
         }
 
-        var document: String {
+        var document: String? {
             if let deprecationMessage {
-                return self._document.dropFirst(deprecationMessage.count).trimmingCharacters(in: .whitespacesAndNewlines)
+                return formatDocumentation(self._document.dropFirst(deprecationMessage.count))
             } else {
-                return self._document.trimmingCharacters(in: .whitespacesAndNewlines)
+                return formatDocumentation(self._document)
             }
         }
 

--- a/Sources/TecoServiceGenerator/models/APIObject.swift
+++ b/Sources/TecoServiceGenerator/models/APIObject.swift
@@ -4,7 +4,7 @@ struct APIObject: Codable {
     private let _type: `Type`?
     var usage: Usage?
 
-    var document: String? { formatModelDocumentation(self._document) }
+    var document: String? { formatDocumentation(self._document) }
     var type: `Type` { self._type ?? .object }
     var initializable: Bool { self.usage == .in || self.usage == .both }
 
@@ -33,7 +33,7 @@ struct APIObject: Codable {
         let member: String
         let type: APIObject.`Type`
 
-        var document: String? { formatModelDocumentation(self._document) }
+        var document: String? { formatDocumentation(self._document) }
         var disabled: Bool { self._disabled ?? false }
         var required: Bool { self._required ?? true }
         var outputRequired: Bool { self._output_required ?? true }


### PR DESCRIPTION
This PR implements robust matching of various HTML tags in documentation metadata, and converts them to nice-looking Markdown syntax that is supported by DocC. It also converts `<dx-alert>` blocks and `>?` attributes to DocC blocks.

Closes #36.

Transformed:
- `<a>`
- `<b>` 
- `<code>`
- `<del>`
- `<h1>`/`<h2>`/`<h3>`/`<h4>`/`<h5>`
- `<p>`
- `<strong>`
- `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>`
- `<ul>`/`<li>`

Stripped:
- `<div>`
- `<font>`
- `<pre>`
- `<span>`

We may further improve all these stuff in some later PR, but that should have minor impact on the rules.