### PR TITLE
Bumps `teco-core` requirement to 0.5.3 everywhere

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teco-project/teco-core.git",
       "state" : {
-        "revision" : "726210465e1f4cd6ed3d17e13050b73c47e0c993",
-        "version" : "0.5.1"
+        "revision" : "6bdf166c5284a1a4b178080fe563fe3db06e5363",
+        "version" : "0.5.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-        .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.0")),
+        .package(url: "https://github.com/teco-project/teco-core.git", .upToNextMinor(from: "0.5.3")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/TecoPackageGenerator/generator.swift
+++ b/Sources/TecoPackageGenerator/generator.swift
@@ -17,7 +17,7 @@ struct TecoPackageGenerator: TecoCodeGenerator {
     var serviceGenerator: URL?
 
     @Option(name: .long, transform: parseLabeledExprSyntax)
-    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.0")"#))
+    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.3")"#))
 
     @Flag
     var dryRun: Bool = false

--- a/Sources/TecoRegionDataGenerator/helpers.swift
+++ b/Sources/TecoRegionDataGenerator/helpers.swift
@@ -6,7 +6,7 @@ func getRegionMap(from regionInfo: [RegionInfo]) -> OrderedDictionary<String, St
     return .init(uncheckedUniqueKeysWithValues: regions)
 }
 
-private struct DescribeRegionsRequest: TCRequestModel {
+private struct DescribeRegionsRequest: TCRequest {
     let product: String
 
     enum CodingKeys: String, CodingKey {
@@ -14,7 +14,7 @@ private struct DescribeRegionsRequest: TCRequestModel {
     }
 }
 
-private struct DescribeRegionsResponse: TCResponseModel {
+private struct DescribeRegionsResponse: TCResponse {
     let totalCount: UInt64
     let regionSet: [RegionInfo]
     let requestId: String
@@ -53,9 +53,11 @@ struct RegionService: TCService {
     }
 
     func describeRegions(for product: String) async throws -> [RegionInfo] {
-        try await self.client.execute(action: "DescribeRegions",
-                                      serviceConfig: self.config,
-                                      input: DescribeRegionsRequest(product: product),
-                                      outputs: DescribeRegionsResponse.self).get().regionSet
+        try await self.client.execute(
+            action: "DescribeRegions",
+            serviceConfig: self.config,
+            input: DescribeRegionsRequest(product: product),
+            outputs: DescribeRegionsResponse.self)
+        .get().regionSet
     }
 }

--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -55,7 +55,7 @@ func buildInitializerParameterList(for members: [APIObject.Member], includeDepre
 func buildRequestModelDecl(for input: String, metadata: APIObject, pagination: Pagination?, output: (name: String, metadata: APIObject)) throws -> StructDeclSyntax {
     try StructDeclSyntax("""
         \(raw: buildDocumentation(summary: metadata.document))
-        public struct \(raw: input): \(raw: pagination != nil ? "TCPaginatedRequest" : "TCRequestModel")
+        public struct \(raw: input): \(raw: pagination != nil ? "TCPaginatedRequest" : "TCRequest")
         """) {
         let inputMembers = metadata.members.filter({ $0.type != .binary })
         buildModelMemberList(for: input, usage: .in, members: inputMembers)
@@ -97,7 +97,7 @@ func buildModelMemberList(for model: String, usage: APIObject.Usage?, members: [
 func buildResponseModelDecl(for output: String, metadata: APIObject, wrapped: Bool, paginated: Bool) throws -> StructDeclSyntax {
     try StructDeclSyntax("""
         \(raw: buildDocumentation(summary: metadata.document))
-        public struct \(raw: output): \(raw: paginated ? "TCPaginatedResponse" : "TCResponseModel")
+        public struct \(raw: output): \(raw: paginated ? "TCPaginatedResponse" : "TCResponse")
         """) {
 
         if wrapped {


### PR DESCRIPTION
This PR bumps `teco-core` version requirement to 0.5.3 both in `teco-code-generators` and `teco`. It also adjusts generator rules according to `teco-core` 0.5.3 deprecations.