### PR TITLE
Implements support for nested pagination key

### DIFF
--- a/Sources/TecoCodeGeneratorCommons/Utils.swift
+++ b/Sources/TecoCodeGeneratorCommons/Utils.swift
@@ -32,6 +32,10 @@ extension String {
         return false
     }
 
+    public func swiftMemberEscaped() -> String {
+        self == "init" ? "`init`" : self
+    }
+
     public func swiftIdentifierEscaped() -> String {
         (self == "init" || self.isSwiftKeyword) ? "`\(self)`" : self
     }

--- a/Sources/TecoServiceGenerator/builders/Model.swift
+++ b/Sources/TecoServiceGenerator/builders/Model.swift
@@ -169,8 +169,7 @@ func buildModelInitializerDeclSyntax(for model: String, members: [APIObject.Memb
                     self.\(raw: "_\(member.identifier)") = .init(wrappedValue: \(raw: member.escapedIdentifier))
                     """)
             } else {
-                let identifier = member.identifier
-                ExprSyntax("self.\(raw: identifier == "init" ? "`init`" : identifier) = \(raw: member.escapedIdentifier)")
+                ExprSyntax("self.\(raw: member.memberIdentifier) = \(raw: member.escapedIdentifier)")
             }
         }
     }

--- a/Sources/TecoServiceGenerator/builders/Pagination.swift
+++ b/Sources/TecoServiceGenerator/builders/Pagination.swift
@@ -108,15 +108,15 @@ private func buildNextInputExpr(for pagination: Pagination, members: [APIObject.
 
 private func buildHasMoreResultExpr(for output: APIObject, pagination: Pagination) -> ExprSyntax {
     // See if there's indicator for more result.
-    if let (key, metadata) = output.getFieldExactly({ $0.name.hasPrefix("HasNext") }) {
+    if let (key, metadata) = output.getFieldExactly(predicate: { $0.name.hasPrefix("HasNext") }) {
         precondition(metadata.optional == false && metadata.type == .bool)
         return ExprSyntax("response.\(raw: key)")
     }
-    if let (key, metadata) = output.getFieldExactly({ $0.name == "HasMore" }) {
+    if let (key, metadata) = output.getFieldExactly(predicate: { $0.name == "HasMore" }) {
         precondition(metadata.type == .int)
         return ExprSyntax("response.\(raw: key) == 1")
     }
-    if let (key, metadata) = output.getFieldExactly({ $0.name == "HaveMore" }) {
+    if let (key, metadata) = output.getFieldExactly(predicate: { $0.name == "HaveMore" }) {
         precondition(metadata.optional == false)
         switch metadata.type {
         case .int:

--- a/Sources/TecoServiceGenerator/builders/Pagination.swift
+++ b/Sources/TecoServiceGenerator/builders/Pagination.swift
@@ -1,13 +1,14 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 @_implementationOnly import OrderedCollections
+@_implementationOnly import RegexBuilder
 
 func buildGetItemsDecl(with field: APIObject.Field) -> DeclSyntax {
     let memberType = getSwiftMemberType(for: field.metadata)
     return DeclSyntax("""
         /// Extract the returned ``\(raw: memberType)`` list from the paginated response.
         public func getItems() -> [\(raw: memberType)] {
-            self.\(raw: field.key)\(raw: field.metadata.optional || field.key.contains("?") ? " ?? []" : "")
+            self.\(raw: removingOptionalAccess(from: field.key))\(raw: field.key.contains("?") ? " ?? []" : "")
         }
         """)
 }
@@ -16,7 +17,7 @@ func buildGetTotalCountDecl(with field: APIObject.Field) -> DeclSyntax {
     DeclSyntax("""
         /// Extract the total count from the paginated response.
         public func getTotalCount() -> \(raw: getSwiftType(for: field.metadata, forceOptional: true)) {
-            self.\(raw: field.key)
+            self.\(raw: removingOptionalAccess(from: field.key))
         }
         """)
 }
@@ -34,16 +35,25 @@ func buildMakeNextRequestDecl(for pagination: Pagination, input: (name: String, 
 }
 
 private func buildNextInputExpr(for pagination: Pagination, members: [APIObject.Member], prefix: String = "self") -> ExprSyntax {
-    func buildInputExpr(for members: [APIObject.Member], updating keyPath: some Collection<String>, to value: String, defaultValue: String, prefix: String = "self", excludeOthers: Bool = false) -> FunctionCallExprSyntax {
-        // Key path shouldn't be empty.
-        guard let nestedIdentifier = keyPath.first else {
-            fatalError("'keyPath' must not be empty.")
+    func buildInputExpr(for members: [APIObject.Member], updating keyPath: String, to value: String, defaultValue: String, prefix: String = "self", excludeOthers: Bool = false) -> FunctionCallExprSyntax {
+        precondition(keyPath.isEmpty == false, "'keyPath' must not be empty.")
+        // Regex for getting top-level member access.
+        let memberAccessRegex = Regex {
+            Capture {
+                OneOrMore(.any, .reluctant)
+            }
+            "."
+            Capture {
+                OneOrMore(.any)
+            }
         }
         // Get input member list.
         let members = members.filter({ !$0.disabled && $0.type != .binary })
         var parameters = OrderedDictionary(excludeOthers ? [] : members.map({ ($0.identifier, "\(prefix).\($0.memberIdentifier)") }), uniquingKeysWith: { $1 })
-        let identifier = identifierFromEscaped(nestedIdentifier)
-        if case let nestedKeyPath = keyPath.dropFirst(), !nestedKeyPath.isEmpty {
+        // Check if the key path is nested.
+        if let match = keyPath.wholeMatch(of: memberAccessRegex) {
+            let (nestedIdentifier, nestedKeyPath) = (String(match.1), String(match.2))
+            let identifier = identifierFromEscaped(nestedIdentifier)
             // Deep into nested objects.
             guard let member = members.first(where: { $0.identifier == identifier }),
                   member.type == .object,
@@ -55,7 +65,7 @@ private func buildNextInputExpr(for pagination: Pagination, members: [APIObject.
             // Handle optional cases.
             if nestedIdentifier.hasSuffix("?") {
                 let escapedIdentifier = identifier.swiftIdentifierEscaped()
-                let updatedValue = replacingOptionalKeyPath(nestedPrefix, in: value, with: escapedIdentifier)
+                let updatedValue = replacingOptionalKeyPath(nestedPrefix, in: value, with: escapedIdentifier, forceUnwrap: nestedKeyPath.hasSuffix("?"))
                 parameters[identifier] = """
                     {
                         if let \(escapedIdentifier) = \(prefix).\(identifier.swiftMemberEscaped()) {
@@ -70,7 +80,7 @@ private func buildNextInputExpr(for pagination: Pagination, members: [APIObject.
             }
         } else {
             // Handle unnested input normally.
-            parameters[identifier] = value
+            parameters[identifierFromEscaped(keyPath)] = value
         }
         // Build the initializer call syntax.
         return FunctionCallExprSyntax(callee: ExprSyntax(".init")) {
@@ -80,17 +90,17 @@ private func buildNextInputExpr(for pagination: Pagination, members: [APIObject.
         }
     }
     // Compute input key paths.
-    let inputKeyPath: [String] = {
+    let inputKeyPath: String = {
         switch pagination {
         case .token(let input, _), .offset(let input, _), .paged(let input):
-            return input.key.split(separator: ".").map(String.init)
+            return input.key
         }
     }()
     // Compute updated value.
     let (buildUpdatedValue, defaultValue): ((String) -> String, String) = {
         switch pagination {
         case .token(_, let output):
-            return ({ $0 }, "response.\(output.key)")
+            return ({ $0 }, "response.\(removingOptionalAccess(from: output.key))")
         case .offset(let input, let output):
             let expr = nonOptionalIntegerValue(for: input, prefix: "self.")
             if let output {
@@ -114,7 +124,7 @@ private func buildHasMoreResultExpr(for output: APIObject, pagination: Paginatio
     }
     if let (key, metadata) = output.getFieldExactly(predicate: { $0.name == "HasMore" }) {
         precondition(metadata.type == .int)
-        return ExprSyntax("response.\(raw: key) == 1")
+        return ExprSyntax("response.\(raw: removingOptionalAccess(from: key)) == 1")
     }
     if let (key, metadata) = output.getFieldExactly(predicate: { $0.name == "HaveMore" }) {
         precondition(metadata.optional == false)
@@ -124,12 +134,12 @@ private func buildHasMoreResultExpr(for output: APIObject, pagination: Paginatio
         case .bool:
             return ExprSyntax("response.\(raw: key)")
         default:
-            fatalError("Unsupported type \(getSwiftType(for: metadata)) for key 'HaveMore'")
+            fatalError("Unsupported type '\(getSwiftType(for: metadata))' for key 'HaveMore'")
         }
     }
     // See if there's token fot the next page.
     if case .token(_, let output) = pagination, output.metadata.nullable {
-        return ExprSyntax("response.\(raw: output.key) != nil")
+        return ExprSyntax("response.\(raw: removingOptionalAccess(from: output.key)) != nil")
     }
     // If there's no indicator, judge by list empty.
     return ExprSyntax("!response.getItems().isEmpty")

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -6,6 +6,24 @@ enum ServiceContext {
     static var objects: [String : APIObject] = [:]
 }
 
+func identifierFromEscaped(_ identifier: String) -> String {
+    guard !identifier.hasSuffix("?") else {
+        return identifierFromEscaped(.init(identifier.dropLast()))
+    }
+    let escapedIdentifierRegex = Regex {
+        "`"
+        Capture {
+            ZeroOrMore(.any)
+        }
+        "`"
+    }
+    if let match = identifier.wholeMatch(of: escapedIdentifierRegex) {
+        return String(match.1)
+    } else {
+        return identifier
+    }
+}
+
 func skipAuthorizationParameter(for action: String) -> String {
     // Special rule for sts:AssumeRoleWithSAML & sts:AssumeRoleWithWebIdentity
     return action.hasPrefix("AssumeRoleWith") ? ", skipAuthorization: true" : ""

--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -149,4 +149,8 @@ extension APIObject.Member {
     var escapedIdentifier: String {
         self.identifier.swiftIdentifierEscaped()
     }
+
+    var memberIdentifier: String {
+        self.identifier.swiftMemberEscaped()
+    }
 }

--- a/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
@@ -53,7 +53,7 @@ func getTotalCountField(for output: APIObject, associative: Bool = false) -> API
             if let model = ServiceContext.objects[field.metadata.member],
                let count = getTotalCountField(for: model, associative: false)
             {
-                return ("\(field.key)\(field.metadata.optional ? "?" : "").\(count.key)", count.metadata)
+                return ("\(field.key).\(count.key)", count.metadata)
             }
         }
     }
@@ -118,10 +118,11 @@ func computePaginationKind(input: APIObject, output: APIObject, service: APIMode
 
 func nonOptionalIntegerValue(for field: APIObject.Field, prefix: String = "") -> String {
     precondition(field.metadata.type == .int)
+    let key = removingOptionalAccess(from: field.key)
     if field.metadata.optional {
-        return "(\(prefix)\(field.key) ?? 0)"
+        return "(\(prefix)\(key) ?? 0)"
     } else {
-        return "\(prefix)\(field.key)"
+        return "\(prefix)\(key)"
     }
 }
 
@@ -134,7 +135,7 @@ extension APIObject {
             var members = self.members
             members.removeAll(where: { $0.name == "RequestId" })
             if members.count == 1, members[0].type == .object, let model = ServiceContext.objects[members[0].member] {
-                return (model.members, "\(members[0].identifier)\(members[0].optional ? "?" : "")")
+                return (model.members, "\(members[0].memberIdentifier)\(members[0].optional ? "?" : "")")
             } else {
                 return (members, nil)
             }
@@ -144,11 +145,12 @@ extension APIObject {
         guard filtered.count == 1, let field = filtered.first else {
             return nil
         }
+        let member = "\(field.memberIdentifier)\(field.optional ? "?" : "")"
         // If the result is nested, add the prefix accordingly.
         if let prefix {
-            return ("\(prefix).\(field.memberIdentifier)", field)
+            return ("\(prefix).\(member)", field)
         } else {
-            return (field.escapedIdentifier, field)
+            return (member, field)
         }
     }
 }

--- a/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
@@ -130,7 +130,7 @@ extension APIObject {
 
     func getFieldExactly(_ match: (APIObject.Member) throws -> Bool) rethrows -> Field? {
         // If there's only one object in the model, we see it as the root of output.
-        let (members, namespace): (_, String?) = {
+        let (members, prefix): (_, String?) = {
             var members = self.members
             members.removeAll(where: { $0.name == "RequestId" })
             if members.count == 1, members[0].type == .object, let model = ServiceContext.objects[members[0].member] {
@@ -144,9 +144,9 @@ extension APIObject {
         guard filtered.count == 1, let field = filtered.first else {
             return nil
         }
-        // If the result is nested, add its namespace as prefix.
-        if let namespace {
-            return ("\(namespace).\(field.memberIdentifier)", field)
+        // If the result is nested, add the prefix accordingly.
+        if let prefix {
+            return ("\(prefix).\(field.memberIdentifier)", field)
         } else {
             return (field.escapedIdentifier, field)
         }

--- a/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
@@ -16,16 +16,16 @@ enum Pagination {
 }
 
 func getItemsField(for output: APIObject) -> APIObject.Field? {
-    output.getFieldExactly({ $0.type == .list })
+    output.getFieldExactly { $0.type == .list }
 }
 
 func getTotalCountField(for output: APIObject, associative: Bool = false) -> APIObject.Field? {
     // Output contains a total count field.
-    if let field = output.getFieldExactly({ ["TotalCount", "TotalCnt", "TotalNum", "TotalElements", "Total"].contains($0.name) && $0.type == .int }) {
+    if let field = output.getFieldExactly(predicate: { ["TotalCount", "TotalCnt", "TotalNum", "TotalElements", "Total"].contains($0.name) && $0.type == .int }) {
         return field
     }
     // Output contains a single integer field, which we assume to be total count.
-    if let field = output.getFieldExactly({ $0.type == .int }),
+    if let field = output.getFieldExactly(predicate: { $0.type == .int }),
        case let name = field.metadata.name,
        name == "Count" || name.hasPrefix("Total") || name.hasSuffix("Num")
     {
@@ -44,12 +44,12 @@ func getTotalCountField(for output: APIObject, associative: Bool = false) -> API
                 name.removeLast(suffix.count)
                 break
             }
-            if let count = output.getFieldExactly({ $0.type == .int && countSuffices.map({ name + $0 }).contains($0.name) }) {
+            if let count = output.getFieldExactly(predicate: { $0.type == .int && countSuffices.map({ name + $0 }).contains($0.name) }) {
                 return count
             }
         }
         // Associative query into the metadata object.
-        if let field = output.getFieldExactly({ $0.type != .list }), field.metadata.type == .object {
+        if let field = output.getFieldExactly(predicate: { $0.type != .list }), field.metadata.type == .object {
             if let model = ServiceContext.objects[field.metadata.member],
                let count = getTotalCountField(for: model, associative: false)
             {
@@ -67,10 +67,10 @@ func computePaginationKind(input: APIObject, output: APIObject, service: APIMode
         return nil
     }
     // Offset-based pagination marked by "Offset".
-    if let offset = input.getFieldExactly({ $0.name == "Offset" && $0.type == .int }) {
+    if let offset = input.getFieldExactly(predicate: { $0.name == "Offset" && $0.type == .int }) {
         // Output contains "Limit" and "Offset" fields which can be used in pagination.
-        if let _ = output.getFieldExactly({ $0.name == "Offset" && $0.type == .int }),
-           let limit = output.getFieldExactly({ $0.name == "Limit" && $0.type == .int })
+        if let _ = output.getFieldExactly(predicate: { $0.name == "Offset" && $0.type == .int }),
+           let limit = output.getFieldExactly(predicate: { $0.name == "Limit" && $0.type == .int })
         {
             return .offset(input: offset, output: limit)
         }
@@ -79,7 +79,7 @@ func computePaginationKind(input: APIObject, output: APIObject, service: APIMode
             return .offset(input: offset)
         }
         // Output contains no other field than the item list.
-        if let _ = output.getFieldExactly({ _ in true }) {
+        if let _ = output.getFieldExactly(predicate: { _ in true }) {
             return .offset(input: offset)
         }
         // The item list is named "Items" and contains a list of "Item"s.
@@ -87,29 +87,29 @@ func computePaginationKind(input: APIObject, output: APIObject, service: APIMode
             return .offset(input: offset)
         }
         // Output only contains a list and a object holding query metadata.
-        if let field = output.getFieldExactly({ $0.type != .list }), field.metadata.type == .object {
+        if let field = output.getFieldExactly(predicate: { $0.type != .list }), field.metadata.type == .object {
             return .offset(input: offset)
         }
         // Output contains a "Total" field in non-integer which we cannot make use of at the point.
-        if let _ = output.getFieldExactly({ $0.name == "Total" }) {
+        if let _ = output.getFieldExactly(predicate: { $0.name == "Total" }) {
             return .offset(input: offset)
         }
         // All other situations are regarded as illegal for pagination.
         return nil
     }
     // Token-based pagination marked by common "Token" or "Cursor" fields.
-    if let token = input.getFieldExactly({ $0.name.hasSuffix("Token") || $0.name.hasSuffix("Cursor") }) {
+    if let token = input.getFieldExactly(predicate: { $0.name.hasSuffix("Token") || $0.name.hasSuffix("Cursor") }) {
         // Output must contain an associated token field named like "[Next]Token" or "[Next]Cursor".
-        if let outputToken = output.getFieldExactly({ $0.name == token.metadata.name || $0.name == "Next\(token.metadata.name)" }) {
+        if let outputToken = output.getFieldExactly(predicate: { $0.name == token.metadata.name || $0.name == "Next\(token.metadata.name)" }) {
             // Token fields should share the same type.
             precondition(token.metadata.type == outputToken.metadata.type && token.metadata.member == outputToken.metadata.member)
             return .token(input: token, output: outputToken)
         }
     }
     // Page-based pagination marked by "PageSize".
-    if let _ = input.getFieldExactly({ $0.name == "PageSize" }) {
+    if let _ = input.getFieldExactly(predicate: { $0.name == "PageSize" }) {
         // Try to find a page number field which is incremented 1 by a time.
-        if let field = input.getFieldExactly({ ["PageNo", "PageNum", "PageNumber", "PageId", "PageIndex"].contains($0.name) && $0.type == .int }) {
+        if let field = input.getFieldExactly(predicate: { ["PageNo", "PageNum", "PageNumber", "PageId", "PageIndex"].contains($0.name) && $0.type == .int }) {
             return .paged(input: field)
         }
     }
@@ -128,7 +128,7 @@ func nonOptionalIntegerValue(for field: APIObject.Field, prefix: String = "") ->
 extension APIObject {
     typealias Field = (key: String, metadata: APIObject.Member)
 
-    func getFieldExactly(_ match: (APIObject.Member) throws -> Bool) rethrows -> Field? {
+    func getFieldExactly(excludingDisabled: Bool = true, predicate: (APIObject.Member) throws -> Bool) rethrows -> Field? {
         // If there's only one object in the model, we see it as the root of output.
         let (members, prefix): (_, String?) = {
             var members = self.members
@@ -140,7 +140,7 @@ extension APIObject {
             }
         }()
         // Check if the matched field is the only one.
-        let filtered = try members.filter(match)
+        let filtered = try members.filter(predicate).filter({ !(excludingDisabled && $0.disabled) })
         guard filtered.count == 1, let field = filtered.first else {
             return nil
         }

--- a/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
@@ -116,13 +116,14 @@ func computePaginationKind(input: APIObject, output: APIObject, service: APIMode
     return nil
 }
 
-func nonOptionalIntegerValue(for field: APIObject.Field, prefix: String = "") -> String {
-    precondition(field.metadata.type == .int)
-    let key = removingOptionalAccess(from: field.key)
-    if field.metadata.optional {
-        return "(\(prefix)\(key) ?? 0)"
+func nonOptionalValue(for keyPath: String, default: String? = nil) -> String {
+    if keyPath.contains("?") {
+        guard let `default` else {
+            preconditionFailure("Unspecified default value for optional key path '\(keyPath)'")
+        }
+        return "(\(removingOptionalAccess(from: keyPath)) ?? \(`default`))"
     } else {
-        return "\(prefix)\(key)"
+        return keyPath
     }
 }
 

--- a/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/PaginationHelpers.swift
@@ -146,7 +146,7 @@ extension APIObject {
         }
         // If the result is nested, add its namespace as prefix.
         if let namespace {
-            return ("\(namespace).\(field.identifier)", field)
+            return ("\(namespace).\(field.memberIdentifier)", field)
         } else {
             return (field.escapedIdentifier, field)
         }


### PR DESCRIPTION
This PR introduces support for pagination input key that's nested in deeper objects. It also improves pagination detection rules and adds some useful helpers like `APIObject.Member.memberIdentifier`.