### PR TITLE
Updates DocC asides to use `>` instead of `-`

### DIFF
--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -596,7 +596,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
             let prefix: String
             switch infotype {
             case "notice":
-                prefix = "Attention"
+                prefix = "Important"
             case "explain":
                 prefix = "Note"
             default:
@@ -612,7 +612,7 @@ func formatDocumentation(_ documentation: String?) -> String? {
         }
     }
 
-    // Convert `>?` to DocC attention aside
+    // Convert `>?` to DocC important aside
     do {
         let attentionMarkRegex = Regex {
             Optionally(.newlineSequence)
@@ -639,10 +639,10 @@ func formatDocumentation(_ documentation: String?) -> String? {
                 return "\n#### Attention\n"
             }
             guard let contentMatch = try? attentionPrefixRegex.wholeMatch(in: match.1) else {
-                assertionFailure("Unable to extract content in attention aside.")
+                assertionFailure("Unable to extract content in >? aside.")
                 return "\(match.1)"
             }
-            return "\n> Attention: \(contentMatch.1)"
+            return "\n> Important: \(contentMatch.1)"
         }
     }
 

--- a/Sources/TecoServiceGenerator/helpers.swift
+++ b/Sources/TecoServiceGenerator/helpers.swift
@@ -556,7 +556,10 @@ func formatDocumentation(_ documentation: String?) -> String? {
             One(.newlineSequence)
             ">"
             ZeroOrMore(.whitespace, .reluctant)
-            One(.newlineSequence)
+            ChoiceOf {
+                One(.newlineSequence)
+                Anchor.endOfSubject
+            }
         }
         let documentationCopy = documentation
         documentation.replace(unwantedAngleRegex) { match in


### PR DESCRIPTION
The `>` syntax for asides is documented in https://www.swift.org/documentation/docc/formatting-your-documentation-content#Add-Notes-and-Other-Asides. Although it's not being highlighted in Xcode, DocC renders it correctly, so let's switch.

This PR also updates the term "DocC block" to "aside", changes "Attention" aside into "Important" and improves stripping out unnecessary `>`s.