### PR TITLE
Removes `import TecoPaginationHelpers` that's no longer necessary

### DIFF
--- a/Sources/TecoPackageGenerator/generator.swift
+++ b/Sources/TecoPackageGenerator/generator.swift
@@ -17,7 +17,7 @@ struct TecoPackageGenerator: TecoCodeGenerator {
     var serviceGenerator: URL?
 
     @Option(name: .long, transform: parseLabeledExprSyntax)
-    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.3")"#))
+    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.5")"#))
 
     @Flag
     var dryRun: Bool = false

--- a/Sources/TecoServiceGenerator/builder.swift
+++ b/Sources/TecoServiceGenerator/builder.swift
@@ -4,7 +4,7 @@ import TecoCodeGeneratorCommons
 
 enum ImportContext {
     case client
-    case action(input: APIObject, output: APIObject, pagination: Bool)
+    case action(input: APIObject, output: APIObject)
     case models(any Collection<APIObject>)
     case error
     case exports(any Collection<APIObject>)
@@ -13,7 +13,7 @@ enum ImportContext {
 func buildTecoCoreImportDecls(for context: ImportContext) -> CodeBlockItemListSyntax {
     let date = {
         let members: [APIObject.Member]
-        if case .action(let input, let output, _) = context {
+        if case .action(let input, let output) = context {
             members = input.members + output.members
         } else if case .models(let models) = context {
             members = models.flatMap(\.members)
@@ -46,7 +46,7 @@ func buildTecoCoreImportDecls(for context: ImportContext) -> CodeBlockItemListSy
             if date {
                 DeclSyntax("import TecoDateHelpers")
             }
-        case .action(_, _, let pagination):
+        case .action:
             if date {
                 DeclSyntax("import struct Foundation.Date")
             }
@@ -55,9 +55,6 @@ func buildTecoCoreImportDecls(for context: ImportContext) -> CodeBlockItemListSy
             DeclSyntax("import TecoCore")
             if date {
                 DeclSyntax("import TecoDateHelpers")
-            }
-            if pagination {
-                DeclSyntax("import TecoPaginationHelpers")
             }
         }
     }

--- a/Sources/TecoServiceGenerator/generator.swift
+++ b/Sources/TecoServiceGenerator/generator.swift
@@ -130,7 +130,7 @@ struct TecoServiceGenerator: TecoCodeGenerator {
                     let pagination = computePaginationKind(input: input, output: output, service: service, action: metadata)
 
                     let sourceFile = try SourceFileSyntax {
-                        buildTecoCoreImportDecls(for: .action(input: input, output: output, pagination: pagination != nil))
+                        buildTecoCoreImportDecls(for: .action(input: input, output: output))
 
                         let inputMembers = input.members.filter({ $0.type != .binary })
                         let discardableOutput = output.type == .object && output.members.count == 1


### PR DESCRIPTION
Teco Core v0.5.5 has merged pagination support into `TecoCore`, so `import TecoPaginationHelpers` is no longer necessary.