### PR TITLE
Uses globally shared `TCClient` by default

### DIFF
--- a/Sources/TecoPackageGenerator/generator.swift
+++ b/Sources/TecoPackageGenerator/generator.swift
@@ -17,7 +17,7 @@ struct TecoPackageGenerator: TecoCodeGenerator {
     var serviceGenerator: URL?
 
     @Option(name: .long, transform: parseLabeledExprSyntax)
-    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.5")"#))
+    var tecoCoreRequirement: LabeledExprSyntax = .init(expression: ExprSyntax(#".upToNextMinor(from: "0.5.6")"#))
 
     @Flag
     var dryRun: Bool = false

--- a/Sources/TecoServiceGenerator/builder.swift
+++ b/Sources/TecoServiceGenerator/builder.swift
@@ -104,7 +104,7 @@ func buildServiceInitializerDecl(with serviceMetadata: APIModel.Metadata, hasErr
         ///    - timeout: Timeout value for HTTP requests.
         ///    - byteBufferAllocator: Byte buffer allocator used throughout ``\(raw: serviceMetadata.shortName.upperFirst())``.
         public init(
-            client: TCClient,
+            client: TCClient = .shared,
             region: TCRegion? = nil,
             language: TCServiceConfig.Language? = nil,
             endpoint: TCServiceConfig.Endpoint = .global,


### PR DESCRIPTION
This PR updates Teco with default `client` as `TCClient.shared`, introduced in Teco Core v0.5.6.