### PR TITLE
Updates `TCDateWrapper`s for better API

### DIFF
--- a/Sources/TecoDateWrapperGenerator/builder.swift
+++ b/Sources/TecoDateWrapperGenerator/builder.swift
@@ -13,6 +13,7 @@ func buildImportDecls(for encoding: DateEncoding) -> CodeBlockItemListSyntax {
         DeclSyntax("import struct Foundation.Date")
         DeclSyntax("import class Foundation.ISO8601DateFormatter")
     }
+    DeclSyntax("@_implementationOnly import struct NIOConcurrencyHelpers.NIOLockedValueBox")
 }
 
 func buildDateFormatterDecl(for encoding: DateEncoding) -> DeclSyntax {

--- a/Sources/TecoDateWrapperGenerator/builder.swift
+++ b/Sources/TecoDateWrapperGenerator/builder.swift
@@ -24,13 +24,13 @@ func buildDateFormatterDecl(for encoding: DateEncoding) -> DeclSyntax {
         dateFormat = "yyyy-MM-dd HH:mm:ss"
     case .timestamp_iso8601:
         return DeclSyntax("""
-            public static var _formatter: ISO8601DateFormatter {
+            @_spi(_TecoInternals) public static var _formatter: ISO8601DateFormatter {
                 ISO8601DateFormatter()
             }
             """)
     }
     return DeclSyntax("""
-        public static var _formatter: DateFormatter {
+        @_spi(_TecoInternals) public static var _formatter: DateFormatter {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.dateFormat = \(literal: dateFormat)

--- a/Sources/TecoDateWrapperGenerator/generator.swift
+++ b/Sources/TecoDateWrapperGenerator/generator.swift
@@ -22,24 +22,24 @@ struct TecoDateWrapperGenerator: TecoCodeGenerator {
                     @propertyWrapper
                     public struct \(raw: encoding.rawValue)<WrappedValue: TCDateValue>: Codable
                     """) {
-                    DeclSyntax("public var wrappedValue: WrappedValue { self._dateValue }")
+                    DeclSyntax("public var wrappedValue: WrappedValue { self.date }")
 
                     DeclSyntax("""
                         public var projectedValue: StorageValue {
-                            get { self._stringValue.withLockedValue { $0 } }
+                            get { self.string.withLockedValue { $0 } }
                             nonmutating set {
-                                self._stringValue.withLockedValue { $0 = newValue }
+                                self.string.withLockedValue { $0 = newValue }
                             }
                         }
                         """)
 
-                    DeclSyntax("private let _dateValue: WrappedValue")
-                    DeclSyntax("private let _stringValue: NIOLockedValueBox<StorageValue>")
+                    DeclSyntax("private let date: WrappedValue")
+                    DeclSyntax("private let string: NIOLockedValueBox<StorageValue>")
 
                     DeclSyntax("""
                         public init(wrappedValue: WrappedValue) {
-                            self._dateValue = wrappedValue
-                            self._stringValue = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
+                            self.date = wrappedValue
+                            self.string = NIOLockedValueBox(wrappedValue.encode(formatter: Self._formatter))
                         }
                         """)
 
@@ -47,8 +47,8 @@ struct TecoDateWrapperGenerator: TecoCodeGenerator {
                         public init(from decoder: Decoder) throws {
                             let container = try decoder.singleValueContainer()
                             let dateString = try container.decode(StorageValue.self)
-                            self._dateValue = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
-                            self._stringValue = NIOLockedValueBox(dateString)
+                            self.date = try WrappedValue.decode(from: dateString, formatter: Self._formatter, container: container, wrapper: Self.self)
+                            self.string = NIOLockedValueBox(dateString)
                         }
                         """)
                 }

--- a/Sources/TecoDateWrapperGenerator/generator.swift
+++ b/Sources/TecoDateWrapperGenerator/generator.swift
@@ -52,7 +52,7 @@ struct TecoDateWrapperGenerator: TecoCodeGenerator {
 
                 try ExtensionDeclSyntax("extension \(raw: encoding.rawValue): TCDateWrapper") {
                     DeclSyntax("""
-                        public static var _valueDescription: String {
+                        @_spi(_TecoInternals) public static var _valueDescription: StaticString {
                             \(literal: encoding.valueDescription)
                         }
                         """)


### PR DESCRIPTION
This PR updates `TecoDateWrapperGenerator` to implement non-mutating setter for `$TCDateWrapper`, as well as introducing SPI in `TCDateWrapper` requirements.