### PR TITLE
Improves case-by-case documentation of wrapped date members in Teco

### DIFF
--- a/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
+++ b/Sources/TecoServiceGenerator/helpers/ModelHelpers.swift
@@ -64,8 +64,8 @@ func publicLetWithWrapper(for member: APIObject.Member, documentation: String = 
             documentation += "///\n"
         }
         return """
-            \(documentation)/// While the wrapped date value is immutable just like other fields, you can customize the projected
-            /// string value (through `$`-prefix) in case the synthesized encoding is incorrect.
+            \(documentation)/// While the wrapped date value is immutable just like other fields, you can customize the underlying
+            /// string value (through `$\(member.identifier)`) in case the synthesized encoding is incorrect.
             \(availablility)@\(dateType.propertyWrapper) public var
             """
     } else {


### PR DESCRIPTION
This is a trivial change that specializes the wording of "`$`-prefix" in documentation into the real symbol name.